### PR TITLE
Accept String as a pattern

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,3 +11,10 @@ require 'rake/extensiontask'
 Rake::ExtensionTask.new("strscan")
 
 task :default => [:compile, :test]
+
+desc "Run benchmark"
+task :benchmark do
+  ruby("-S",
+       "benchmark-driver",
+       "benchmark/scan.yaml")
+end

--- a/benchmark/scan.yaml
+++ b/benchmark/scan.yaml
@@ -1,0 +1,9 @@
+prelude: |-
+  $LOAD_PATH.unshift(File.expand_path("lib"))
+  require "strscan"
+  scanner = StringScanner.new("test string")
+benchmark:
+  regexp: |
+    scanner.scan(/\w/)
+  string: |
+    scanner.scan("test")

--- a/strscan.gemspec
+++ b/strscan.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.license = "BSD-2-Clause"
 
   s.add_development_dependency "rake-compiler"
+  s.add_development_dependency "benchmark-driver"
 end


### PR DESCRIPTION
It's only for head only match case such as StringScanner#scan.

If we use a String as a pattern, we can improve match performance.
Here is a result of the including benchmark. It shows String as a
pattern is 1.25x faster than Regexp as a pattern.

    % rake benchmark
    /tmp/local/bin/ruby -S benchmark-driver benchmark/scan.yaml
    Warming up --------------------------------------
                  regexp    12.094M i/s -     12.242M times in 1.012250s (82.69ns/i, 277clocks/i)
                  string    14.653M i/s -     14.889M times in 1.016124s (68.25ns/i, 252clocks/i)
    Calculating -------------------------------------
                  regexp    14.713M i/s -     36.281M times in 2.465970s (67.97ns/i, 254clocks/i)
                  string    18.422M i/s -     43.959M times in 2.386255s (54.28ns/i, 201clocks/i)

    Comparison:
                  string:  18421631.8 i/s
                  regexp:  14712660.7 i/s - 1.25x  slower