### PR TITLE
Fix anchors

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -478,13 +478,13 @@ strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly
         if (!tmpreg) RREGEXP(pattern)->usecnt++;
 
         if (headonly) {
-            ret = onig_match(re, (UChar* )CURPTR(p),
+            ret = onig_match(re, (UChar* )S_PBEG(p),
                              (UChar* )(CURPTR(p) + S_RESTLEN(p)),
                              (UChar* )CURPTR(p), &(p->regs), ONIG_OPTION_NONE);
         }
         else {
             ret = onig_search(re,
-                              (UChar* )CURPTR(p), (UChar* )(CURPTR(p) + S_RESTLEN(p)),
+                              (UChar* )S_PBEG(p), (UChar* )(CURPTR(p) + S_RESTLEN(p)),
                               (UChar* )CURPTR(p), (UChar* )(CURPTR(p) + S_RESTLEN(p)),
                               &(p->regs), ONIG_OPTION_NONE);
         }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -450,7 +450,6 @@ static VALUE
 strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly)
 {
     struct strscanner *p;
-    long moved;
 
     if (headonly) {
         if (!RB_TYPE_P(pattern, T_REGEXP)) {
@@ -520,16 +519,18 @@ strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly
 
     MATCHED(p);
     p->prev = p->curr;
-    moved = p->regs.end[0] - p->prev;
 
     if (succptr) {
         p->curr = p->regs.end[0];
     }
-    if (getstr) {
-        return extract_beg_len(p, p->prev, moved);
-    }
-    else {
-        return INT2FIX(moved);
+    {
+      long length = p->regs.end[0] - p->prev;
+      if (getstr) {
+        return extract_beg_len(p, p->prev, length);
+      }
+      else {
+        return INT2FIX(length);
+      }
     }
 }
 

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -450,6 +450,7 @@ static VALUE
 strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly)
 {
     struct strscanner *p;
+    long moved;
 
     if (headonly) {
         if (!RB_TYPE_P(pattern, T_REGEXP)) {
@@ -514,19 +515,21 @@ strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly
             return Qnil;
         }
         onig_region_clear(&(p->regs));
-        onig_region_set(&(p->regs), 0, 0, RSTRING_LEN(pattern));
+        onig_region_set(&(p->regs), 0, p->curr, p->curr + RSTRING_LEN(pattern));
     }
 
     MATCHED(p);
     p->prev = p->curr;
+    moved = p->regs.end[0] - p->prev;
+
     if (succptr) {
-        p->curr += p->regs.end[0];
+        p->curr = p->regs.end[0];
     }
     if (getstr) {
-        return extract_beg_len(p, p->prev, p->regs.end[0]);
+        return extract_beg_len(p, p->prev, moved);
     }
     else {
-        return INT2FIX(p->regs.end[0]);
+        return INT2FIX(moved);
     }
 }
 
@@ -728,7 +731,7 @@ static void
 adjust_registers_to_matched(struct strscanner *p)
 {
     onig_region_clear(&(p->regs));
-    onig_region_set(&(p->regs), 0, 0, (int)(p->curr - p->prev));
+    onig_region_set(&(p->regs), 0, (int)p->prev, (int)p->curr);
 }
 
 /*
@@ -762,8 +765,7 @@ strscan_getch(VALUE self)
     p->curr += len;
     MATCHED(p);
     adjust_registers_to_matched(p);
-    return extract_range(p, p->prev + p->regs.beg[0],
-                            p->prev + p->regs.end[0]);
+    return extract_range(p, p->regs.beg[0], p->regs.end[0]);
 }
 
 /*
@@ -796,8 +798,7 @@ strscan_get_byte(VALUE self)
     p->curr++;
     MATCHED(p);
     adjust_registers_to_matched(p);
-    return extract_range(p, p->prev + p->regs.beg[0],
-                            p->prev + p->regs.end[0]);
+    return extract_range(p, p->regs.beg[0], p->regs.end[0]);
 }
 
 /*
@@ -975,8 +976,7 @@ strscan_matched(VALUE self)
 
     GET_SCANNER(self, p);
     if (! MATCHED_P(p)) return Qnil;
-    return extract_range(p, p->prev + p->regs.beg[0],
-                            p->prev + p->regs.end[0]);
+    return extract_range(p, p->regs.beg[0], p->regs.end[0]);
 }
 
 /*
@@ -1072,8 +1072,7 @@ strscan_aref(VALUE self, VALUE idx)
     if (i >= p->regs.num_regs) return Qnil;
     if (p->regs.beg[i] == -1)  return Qnil;
 
-    return extract_range(p, p->prev + p->regs.beg[i],
-                            p->prev + p->regs.end[i]);
+    return extract_range(p, p->regs.beg[i], p->regs.end[i]);
 }
 
 /*
@@ -1178,7 +1177,7 @@ strscan_pre_match(VALUE self)
 
     GET_SCANNER(self, p);
     if (! MATCHED_P(p)) return Qnil;
-    return extract_range(p, 0, p->prev + p->regs.beg[0]);
+    return extract_range(p, 0, p->regs.beg[0]);
 }
 
 /*
@@ -1197,7 +1196,7 @@ strscan_post_match(VALUE self)
 
     GET_SCANNER(self, p);
     if (! MATCHED_P(p)) return Qnil;
-    return extract_range(p, p->prev + p->regs.end[0], S_LEN(p));
+    return extract_range(p, p->regs.end[0], S_LEN(p));
 }
 
 /*

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -318,6 +318,10 @@ class TestStringScanner < Test::Unit::TestCase
     s = StringScanner.new("")
     assert_equal 0, s.skip(//)
     assert_equal 0, s.skip(//)
+
+    s = StringScanner.new("a\nb")
+    assert_equal 2, ss.skip(/a\n/)
+    assert_nil      ss.skip(/\Ab/)
   end
 
   def test_getch

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -318,10 +318,13 @@ class TestStringScanner < Test::Unit::TestCase
     s = StringScanner.new("")
     assert_equal 0, s.skip(//)
     assert_equal 0, s.skip(//)
+  end
 
+  def test_skip_with_anchor
     s = StringScanner.new("a\nb")
     assert_equal 2, s.skip(/a\n/)
     assert_nil      s.skip(/\Ab/)
+    assert_equal 1, s.skip(/^b/)
   end
 
   def test_getch

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -320,8 +320,8 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 0, s.skip(//)
 
     s = StringScanner.new("a\nb")
-    assert_equal 2, ss.skip(/a\n/)
-    assert_nil      ss.skip(/\Ab/)
+    assert_equal 2, s.skip(/a\n/)
+    assert_nil      s.skip(/\Ab/)
   end
 
   def test_getch


### PR DESCRIPTION
Six years ago, [the Rouge library](https://github.com/rouge-ruby/rouge) author, @jneen, reported that there was [a bug in the handling of anchors](http://bugs.ruby-lang.org/issues/7092) in StringScanner. At the time, StringScanner did not have a maintainer and the view was expressed that this behaviour was intended.

### The Bug

In short, the bug is that anchors in regular expressions don't work properly in StringScanner. This can be seen in the sample code below (taken from the original bug report):

```ruby
require 'strscan'
ss = StringScanner.new("ab")
ss.scan(/./)
#=> "a"
ss.scan(/^./) # expecting nil, since the head is in the middle of a line
#=> "b"
```

### The Cause

The cause of the bug is the way `strscan_do_scan()` is implemented in `ext/strscan/strscan.c`. This function calls out to `onig_match()` and `onig_search()` like this:

https://github.com/ruby/strscan/blob/cace20fa3729ccd15704e8f08fea32b5a3c37288/ext/strscan/strscan.c#L480-L490 

The reason that the anchors don't work is because the second argument to each method is `CURPTR(p)`. This tells Onigmo to treat _the scan head_ as the beginning of the string to be searched. This is a mistake.

### The Fix

It is clear from the method definitions for `onig_match()` and `onig_search()` (see [here](https://github.com/ruby/ruby/blob/bc8e54911db505d9e1776673a86e956c7d7e3b89/regexec.c#L3866-L3867) and [here](https://github.com/ruby/ruby/blob/bc8e54911db505d9e1776673a86e956c7d7e3b89/regexec.c#L4148-L4150)) that you can begin searching within a string by passing a pointer to the scan head as the fourth argument. [The equivalent function](https://github.com/ruby/ruby/blob/cf930985da1ae15b66577ec8286e54ad04ccda78/re.c#L1561-L1566) used in the implementation of `Regexp`'s search methods (eg. `Regexp#match`) takes this approach: passing different pointers for the start of the string and the location to begin searching.

We can do this in `strscan_do_scan()`:

```c
        if (headonly) {
            ret = onig_match(re, (UChar* )S_PBEG(p),
                             (UChar* )(CURPTR(p) + S_RESTLEN(p)),
                             (UChar* )CURPTR(p), &(p->regs), ONIG_OPTION_NONE);
        }
        else {
            ret = onig_search(re,
                              (UChar* )S_PBEG(p), (UChar* )(CURPTR(p) + S_RESTLEN(p)),
                              (UChar* )CURPTR(p), (UChar* )(CURPTR(p) + S_RESTLEN(p)),
                              &(p->regs), ONIG_OPTION_NONE);
```

However, this change is not enough and will cause various tests in StringScanner's test suite to fail. Because StringScanner calls `onig_match()` and `onig_search()` in the 'wrong way', it has to do various adjustments throughout the file to correct the values of `p->regs` set by Onigmo. Once we remove these adjustments, the tests pass.

### The Result

This PR is **not intended** to be a breaking change. Although, it changes the implementation in `ext/strscan/strscan.c`, the Ruby API returns the same results as it did before the change. Instead, this PR _increases functionality_ by allowing users to use anchors in regular expressions.

It also conforms with the principle of least surprise. A user of StringScanner should be able to use the same regular expressions they could use in `Regexp#match` and get the same results.

Hopefully that all makes sense but please let me know if I can provide any more information.