### PR TITLE
Fix position independent code linking error

### DIFF
--- a/ext/strscan/extconf.rb
+++ b/ext/strscan/extconf.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 require 'mkmf'
-$INCFLAGS << " -I$(top_srcdir) -fPCI"
+$INCFLAGS << " -I$(top_srcdir) -fPIC"
 create_makefile 'strscan'

--- a/ext/strscan/extconf.rb
+++ b/ext/strscan/extconf.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 require 'mkmf'
-$INCFLAGS << " -I$(top_srcdir)"
+$INCFLAGS << " -I$(top_srcdir) -fPCI"
 create_makefile 'strscan'


### PR DESCRIPTION
On a x86_64-linux machine, linking may fail with the following message:

```
/usr/bin/ld: strscan.o: relocation R_X86_64_PC32 against undefined
symbol `rb_eRangeError' can not be used when making a shared object;
recompile with -fPIC
```

Adding `-fPIC` to `$INCFLAGS` fixes this problem.