### PR TITLE
Add a test for when ^ should fail to match

### DIFF
--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -321,10 +321,12 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_skip_with_anchor
-    s = StringScanner.new("a\nb")
+    s = StringScanner.new("a\nbc")
     assert_equal 2, s.skip(/a\n/)
     assert_nil      s.skip(/\Ab/)
     assert_equal 1, s.skip(/^b/)
+    assert_nil      s.skip(/^c/)
+    assert_equal 1, s.skip(/c/)
   end
 
   def test_getch

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -320,13 +320,27 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 0, s.skip(//)
   end
 
-  def test_skip_with_anchor
-    s = StringScanner.new("a\nbc")
+  def test_skip_with_begenning_of_string_anchor_match
+    s = StringScanner.new("a")
+    assert_equal 1, s.skip(/\Aa/)
+  end
+
+  def test_skip_with_begenning_of_string_anchor_not_match
+    s = StringScanner.new("a\nb")
     assert_equal 2, s.skip(/a\n/)
     assert_nil      s.skip(/\Ab/)
+  end
+
+  def test_skip_with_begenning_of_line_anchor_match
+    s = StringScanner.new("a\nb")
+    assert_equal 2, s.skip(/a\n/)
     assert_equal 1, s.skip(/^b/)
-    assert_nil      s.skip(/^c/)
-    assert_equal 1, s.skip(/c/)
+  end
+
+  def test_skip_with_begenning_of_line_anchor_not_match
+    s = StringScanner.new("ab")
+    assert_equal 1, s.skip(/a/)
+    assert_nil      s.skip(/^b/)
   end
 
   def test_getch


### PR DESCRIPTION
Based on the discussion at https://github.com/ruby/strscan/pull/6#issuecomment-515832179, this tests that the behavior of `^` correctly fails to match when the stream is not at the beginning of a line.