### PR TITLE
Replace "iff" with "if and only if"

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -984,7 +984,7 @@ strscan_unscan(VALUE self)
 }
 
 /*
- * Returns +true+ iff the scan pointer is at the beginning of the line.
+ * Returns +true+ if and only if the scan pointer is at the beginning of the line.
  *
  *   s = StringScanner.new("test\ntest\n")
  *   s.bol?           # => true
@@ -1037,7 +1037,7 @@ strscan_empty_p(VALUE self)
 }
 
 /*
- * Returns true iff there is more data in the string.  See #eos?.
+ * Returns true if and only if there is more data in the string.  See #eos?.
  * This method is obsolete; use #eos? instead.
  *
  *   s = StringScanner.new('test string')
@@ -1054,7 +1054,7 @@ strscan_rest_p(VALUE self)
 }
 
 /*
- * Returns +true+ iff the last match was successful.
+ * Returns +true+ if and only if the last match was successful.
  *
  *   s = StringScanner.new('test string')
  *   s.match?(/\w+/)     # => 4


### PR DESCRIPTION
iff means if and only if, but readers without that knowledge might
assume this to be a spelling mistake. To me, this seems like
exclusionary language that is unnecessary. Simply using "if and only if"
instead should suffice.

strscan changes from https://github.com/ruby/ruby/pull/4035