### PR TITLE
CI is fault in ruby-{head/debug}, I don't know why... 😢 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
         - 2.6
         - 2.5
         - 2.4
-        - debug
+        - head
         include:
         - { os: windows-latest , ruby: mingw }
         - { os: windows-latest , ruby: mswin }
         exclude:
         - { os: windows-latest , ruby: 3.0 }
-        - { os: windows-latest , ruby: debug }
+        - { os: windows-latest , ruby: head }
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Sorry, I don't know the details of the difference of this.
But...

* CI is fault even if just updating documents https://github.com/ruby/strscan/pull/21, https://github.com/ruby/strscan/pull/21/checks?check_run_id=2211021486
* https://github.com/ruby/pathname/blob/a71f7d8ed28edae0db219dca7f76f6eaa74de41a/.github/workflows/test.yml#L10 pathname just use head

So this change is okay...?