### PR TITLE
String matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 /_yardoc/
 /coverage/
 /doc/
-/lib/
+/lib/*
+!/lib/strmatch.rb
 /pkg/
 /spec/reports/
 /tmp/

--- a/lib/strmatch.rb
+++ b/lib/strmatch.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# A string scanner that allows selecting based on multiple configured patterns.
+# For example:
+#
+#     matcher = StringMatcher.new("1 2 3")
+#     matcher.match(/\s+/) { |value| { type: :whitespace, value: } }
+#     matcher.match(/\d+/) { |value| { type: :number, value: value.to_i } }
+#
+# The matcher configured above will match on spaces and numbers. You can then
+# use this class to iterate over all of the matches, as in:
+#
+#     until matcher.eos?
+#       case matcher.select
+#       in { type: :whitespace, value: }
+#         puts "SPC: \"#{value}\""
+#       in { type: :number, value: }
+#         puts "NUM: #{value}"
+#       end
+#     end
+#
+# For the input string given in the example above, this will output:
+#
+#     NUM: 1
+#     SPC: " "
+#     NUM: 2
+#     SPC: " "
+#     NUM: 3
+#
+class StringMatcher < StringScanner
+  attr_reader :patterns # :nodoc:
+
+  def initialize(string, fixed_anchor: false) # :nodoc:
+    super(string, fixed_anchor: fixed_anchor)
+    @patterns = []
+  end
+
+  # Configures one of the patterns that will be attempted when the select method
+  # is called. The block given will receive the value returned by the scan
+  # method if it is not nil. The pattern should be the same type as whatever you
+  # would pass to the scan method. For example:
+  #
+  #     matcher = StringMatcher.new("1 2 3")
+  #     matcher.match(/\s+/) { |value| :ws }
+  #     matcher.match(/\d+/) { |value| value.to_i }
+  #
+  # The matcher configured in the block above will yield the symbol literal :ws
+  # and numbers when the select method is called. It will return nil if neither
+  # pattern is matched.
+  def match(pattern, &block)
+    patterns << [pattern, block]
+  end
+
+  # Runs all of the configured patterns and returns the return value of the
+  # block associated with the first pattern that matches.
+  def select
+    patterns.find do |(pattern, block)|
+      value = scan(pattern)
+      break block.call(value) if value
+    end
+  end
+
+  # Runs the select method until the end of the string is reached. If no block
+  # is given, then an enumerator is returned.
+  def select_all
+    return to_enum(__method__) unless block_given?
+    yield select until eos?
+  end
+end

--- a/strscan.gemspec
+++ b/strscan.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.description = "Provides lexical scanning operations on a String."
 
   s.require_path = %w{lib}
-  s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c}
+  s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c lib/strmatch.rb}
   s.extensions = %w{ext/strscan/extconf.rb}
   s.required_ruby_version = ">= 2.4.0"
 

--- a/test/strscan/test_string_matcher.rb
+++ b/test/strscan/test_string_matcher.rb
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+#
+# test/strscan/test_string_matcher.rb
+#
+
+require "strscan"
+require "strmatch"
+require "test/unit"
+
+class TestStringMatcher < Test::Unit::TestCase
+  def test_select
+    matcher = StringMatcher.new("123")
+    matcher.match(/\d/) { |value| value.to_i }
+
+    assert_equal(1, matcher.select)
+    assert_equal(2, matcher.select)
+    assert_equal(3, matcher.select)
+
+    assert_equal(nil, matcher.select)
+    assert_equal(nil, matcher.select)
+  end
+
+  def test_single
+    matcher = StringMatcher.new("123")
+    matcher.match(/\d/) { |value| value.to_i }
+
+    assert_equal([1, 2, 3], matcher.select_all.to_a)
+  end
+
+  def test_multi
+    matcher = StringMatcher.new("1a2b3c")
+    matcher.match(/\d/) { |value| value.to_i }
+    matcher.match(/[a-z]/, &:itself)
+
+    assert_equal([1, "a", 2, "b", 3, "c"], matcher.select_all.to_a)
+  end
+
+  def test_conflicting
+    matcher = StringMatcher.new("123")
+    matcher.match(/\d/) { |value| value.to_i }
+    matcher.match(/\d/, &:itself)
+
+    assert_equal([1, 2, 3], matcher.select_all.to_a)
+  end
+end


### PR DESCRIPTION
Most of the time when I'm using string scanner I am checking multiple patterns. In this case I usually have to join them in a single regex or I just check them with multiple elsif clauses. Instead, it would be nice to initialize a string scanner that could check multiple patterns and then return to me the value that I want. In this commit I introduce a `StringMatcher` object that does just that. For example:

```ruby
require "strmatch"

NumberToken = Struct.new(:value, keyword_init: true)
StringToken = Struct.new(:value, keyword_init: true)

matcher = StringMatcher.new("12ab34")
matcher.match(/\d+/) { |value| NumberToken.new(value: value.to_i) }
matcher.match(/[a-z]+/) { |value| StringToken.new(value:) }

until matcher.eos?
  case matcher.select
  in NumberToken[value:] if value >= 20
    puts "NUMBER: #{value.inspect} (big)"
  in NumberToken[value:] if value < 20
    puts "NUMBER: #{value.inspect} (small)"
  in StringToken[value:]
    puts "STRING: #{value.inspect}"
  end
end
```

Running the above example will produce:

```
NUMBER: 12 (small)
STRING: "ab"
NUMBER: 34 (big)
```

This is more ergonomic since you can now use pattern matching instead of a chain of if/elsif clauses.