### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         - macos-10.15
         - windows-latest
         ruby:
+        - 3.1
         - '3.0'
         - 2.7
         - 2.6


### PR DESCRIPTION
This PR runs green on my fork.  Just adds Ruby 3.1 to the CI matrix.