### PR TITLE
Fix link to CI workflows in the status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StringScanner
 
-![CI](https://github.com/ruby/strscan/workflows/CI/badge.svg?branch=master&event=push)
+[![CI](https://github.com/ruby/strscan/actions/workflows/ci.yml/badge.svg)](https://github.com/ruby/strscan/actions/workflows/ci.yml)
 
 StringScanner provides for lexical scanning operations on a String.
 


### PR DESCRIPTION
I wanted to follow the link in the build status badge, to see the reasons for it being red, but the link was only to the SVG, haha.

This PR changes the link to point to the workflow results page.