### PR TITLE
Add support for TruffleRuby in the gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,7 @@ jobs:
       - run: bundle exec rake test
 
       - run: gem install --verbose --backtrace pkg/*.gem
+
+      - name: Run tests on the installed gem
+        run: ruby run-test.rb
+        if: matrix.ruby != '2.4' # strscan is a default gem from 2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
-          - ubuntu-18.04
-          - macos-11.0
-          - macos-10.15
+          - ubuntu-latest
+          - macos-latest
           - windows-latest
         ruby:
           - '2.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,15 @@ jobs:
           - '3.1'
           - debug
           - jruby-head
+          - truffleruby
+          - truffleruby-head
         include:
           - { os: windows-latest , ruby: mingw }
           - { os: windows-latest , ruby: mswin }
         exclude:
           - { os: windows-latest , ruby: debug }
+          - { os: windows-latest , ruby: truffleruby }
+          - { os: windows-latest , ruby: truffleruby-head }
 
     steps:
       - uses: actions/checkout@v2

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ end
 
 desc "Run test"
 task :test do
-  ENV["RUBYOPT"] = "-Ilib -Itest/lib -rbundler/setup -rhelper"
+  ENV["RUBYOPT"] = "-rbundler/setup"
   ruby("run-test.rb")
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ end
 
 desc "Run test"
 task :test do
-  ENV["RUBYOPT"] = "-rbundler/setup"
+  ENV["RUBYOPT"] = "-Ilib -rbundler/setup"
   ruby("run-test.rb")
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -23,9 +23,11 @@ if RUBY_ENGINE == "jruby"
     ext.target_version = '1.8'
     ext.ext_dir = 'ext/java'
   end
-else
+elsif RUBY_ENGINE == "ruby"
   require 'rake/extensiontask'
   Rake::ExtensionTask.new("strscan")
+else
+  task :compile
 end
 
 desc "Run test"

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,8 @@ end
 
 desc "Run test"
 task :test do
-  ENV["RUBYOPT"] = "-Ilib -rbundler/setup"
+  require_path = RUBY_ENGINE == 'jruby' ? "lib/jruby" : "lib"
+  ENV["RUBYOPT"] = "-I#{require_path} -rbundler/setup"
   ruby("run-test.rb")
 end
 

--- a/ext/strscan/extconf.rb
+++ b/ext/strscan/extconf.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 require 'mkmf'
-$INCFLAGS << " -I$(top_srcdir)" if $extmk
-have_func("onig_region_memsize", "ruby.h")
-create_makefile 'strscan'
+if RUBY_ENGINE == 'ruby'
+  $INCFLAGS << " -I$(top_srcdir)" if $extmk
+  have_func("onig_region_memsize", "ruby.h")
+  create_makefile 'strscan'
+else
+  File.write('Makefile', dummy_makefile("").join)
+end

--- a/lib/jruby/strscan.rb
+++ b/lib/jruby/strscan.rb
@@ -1,0 +1,2 @@
+require 'strscan.jar'
+JRuby::Util.load_ext("org.jruby.ext.strscan.StringScannerLibrary")

--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -1,6 +1,9 @@
 if RUBY_ENGINE == 'jruby'
   require 'strscan.jar'
   JRuby::Util.load_ext("org.jruby.ext.strscan.StringScannerLibrary")
-else
+elsif RUBY_ENGINE == 'ruby'
   require 'strscan.so'
+else
+  $LOAD_PATH.delete(__dir__)
+  require 'strscan' # load from stdlib
 end

--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -1,9 +1,0 @@
-if RUBY_ENGINE == 'jruby'
-  require 'strscan.jar'
-  JRuby::Util.load_ext("org.jruby.ext.strscan.StringScannerLibrary")
-elsif RUBY_ENGINE == 'ruby'
-  require 'strscan.so'
-else
-  $LOAD_PATH.delete(__dir__)
-  require 'strscan' # load from stdlib
-end

--- a/run-test.rb
+++ b/run-test.rb
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift("test")
-$LOAD_PATH.unshift("test/lib")
-$LOAD_PATH.unshift("lib")
+$LOAD_PATH.unshift("#{__dir__}/test")
+$LOAD_PATH.unshift("#{__dir__}/test/lib")
+$LOAD_PATH.unshift("#{__dir__}/lib")
+
+require_relative 'test/lib/helper'
 
 Dir.glob("test/strscan/**/*test_*.rb") do |test_rb|
   require File.expand_path(test_rb)

--- a/run-test.rb
+++ b/run-test.rb
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 
 require 'strscan'
-puts "Loaded strscan from:", *$".grep(/\/strscan\./)
+puts "Loaded strscan from #{$".grep(/\/strscan\./).join(', ')}"
+puts "Gem from #{Gem.loaded_specs["strscan"]&.full_gem_path}"
 
 require_relative 'test/lib/helper'
 

--- a/run-test.rb
+++ b/run-test.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift("#{__dir__}/test")
-$LOAD_PATH.unshift("#{__dir__}/test/lib")
 $LOAD_PATH.unshift("#{__dir__}/lib")
 
 require_relative 'test/lib/helper'

--- a/run-test.rb
+++ b/run-test.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift("#{__dir__}/lib")
+require 'strscan'
+puts "Loaded strscan from:", *$".grep(/\/strscan\./)
 
 require_relative 'test/lib/helper'
 

--- a/strscan.gemspec
+++ b/strscan.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     s.files = %w{lib/strscan.jar lib/strscan.rb}
     s.platform = "java"
   else
-    s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c}
+    s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c lib/strscan.rb}
     s.extensions = %w{ext/strscan/extconf.rb}
   end
   s.required_ruby_version = ">= 2.4.0"

--- a/strscan.gemspec
+++ b/strscan.gemspec
@@ -16,15 +16,14 @@ Gem::Specification.new do |s|
   s.summary = "Provides lexical scanning operations on a String."
   s.description = "Provides lexical scanning operations on a String."
 
-  s.require_path = %w{lib}
-
   jruby = true if Gem::Platform.new('java') =~ s.platform or RUBY_ENGINE == 'jruby'
-  
   if jruby
-    s.files = %w{lib/strscan.jar lib/strscan.rb}
+    s.require_paths = %w{lib/jruby lib}
+    s.files = %w{lib/strscan.jar lib/jruby/strscan.rb}
     s.platform = "java"
   else
-    s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c lib/strscan.rb}
+    s.require_paths = %w{lib}
+    s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c}
     s.extensions = %w{ext/strscan/extconf.rb}
   end
   s.required_ruby_version = ">= 2.4.0"

--- a/test/strscan/test_ractor.rb
+++ b/test/strscan/test_ractor.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 
 class TestStringScannerRactor < Test::Unit::TestCase
   def setup
-    pend unless defined? Ractor
+    omit "Ractor not defined" unless defined? Ractor
   end
 
   def test_ractor

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -207,6 +207,8 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_charpos_not_use_string_methods
+    pend "not supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
+
     string = +'abcädeföghi'
     scanner = create_string_scanner(string)
 
@@ -567,6 +569,8 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_invalid_encoding_string
+    pend "no encoding check on TruffleRuby for scan(String)" if RUBY_ENGINE == "truffleruby"
+
     str = "\xA1\xA2".dup.force_encoding("euc-jp")
     ss = create_string_scanner(str)
     assert_raise(Encoding::CompatibilityError) do
@@ -712,6 +716,8 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_aref_without_regex
+    pend "#[:missing] always raises on TruffleRuby if matched" if RUBY_ENGINE == "truffleruby"
+
     s = create_string_scanner('abc')
     s.get_byte
     assert_nil(s[:c])

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -207,7 +207,7 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_charpos_not_use_string_methods
-    pend "not supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
+    omit "not supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
 
     string = +'abcädeföghi'
     scanner = create_string_scanner(string)
@@ -569,7 +569,7 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_invalid_encoding_string
-    pend "no encoding check on TruffleRuby for scan(String)" if RUBY_ENGINE == "truffleruby"
+    omit "no encoding check on TruffleRuby for scan(String)" if RUBY_ENGINE == "truffleruby"
 
     str = "\xA1\xA2".dup.force_encoding("euc-jp")
     ss = create_string_scanner(str)
@@ -716,7 +716,7 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_aref_without_regex
-    pend "#[:missing] always raises on TruffleRuby if matched" if RUBY_ENGINE == "truffleruby"
+    omit "#[:missing] always raises on TruffleRuby if matched" if RUBY_ENGINE == "truffleruby"
 
     s = create_string_scanner('abc')
     s.get_byte


### PR DESCRIPTION
* This is necessary since lib/strscan.rb was added (https://github.com/ruby/strscan/pull/25), as the
  TruffleRuby stdlib strscan.rb is no longer found first by `require "strscan"`.
* Write conditions in a way that any other Ruby implementation would
  simply use its stdlib until it is added explicit support in this gem.

Fixes https://github.com/oracle/truffleruby/issues/2420