### PR TITLE
Include license in gem

### DIFF
--- a/strscan.gemspec
+++ b/strscan.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
 
   if RUBY_ENGINE == 'jruby'
     s.require_paths = %w{ext/jruby/lib lib}
-    s.files = %w{lib/strscan.jar ext/jruby/lib/strscan.rb}
+    s.files = %w{lib/strscan.jar ext/jruby/lib/strscan.rb LICENSE.txt COPYING}
     s.platform = "java"
   else
     s.require_paths = %w{lib}
-    s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c}
+    s.files = %w{ext/strscan/extconf.rb ext/strscan/strscan.c LICENSE.txt COPYING}
     s.extensions = %w{ext/strscan/extconf.rb}
   end
   s.required_ruby_version = ">= 2.4.0"


### PR DESCRIPTION
why?

```
1. Redistributions of source code must retain the above copyright
   notice, this list of conditions and the following disclaimer.
2. Redistributions in binary form must reproduce the above copyright
   notice, this list of conditions and the following disclaimer in the
   documentation and/or other materials provided with the distribution.
```

AFAIK, a gem is a redistribution of source code and/or binary formats, so it should include the license. Also makes it easier for users of the gem to compile a list of all licenses they use.