### PR TITLE
Add three new methods, see https://github.com/ruby/strscan/issues/50

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -111,6 +111,7 @@ static VALUE strscan_search_full _((VALUE self, VALUE re,
                                     VALUE succp, VALUE getp));
 static void adjust_registers_to_matched _((struct strscanner *p));
 static VALUE strscan_curr_char _((VALUE self));
+static VALUE strscan_next_char _((VALUE self));
 static VALUE strscan_getch _((VALUE self));
 static VALUE strscan_get_byte _((VALUE self));
 static VALUE strscan_getbyte _((VALUE self));
@@ -840,14 +841,12 @@ adjust_registers_to_matched(struct strscanner *p)
 }
 
 /*
- * call-seq: curr_char
- *
  * Extracts the current character without advancing the scan pointer.
  * This method is multibyte character sensitive.
  *
- *   s = StringScanner.new('test')
- *   s.current_char     # => "t"
- *   s.current_char     # => "t"
+ *   s = StringScanner.new('abc')
+ *   s.current_char     # => "a"
+ *   s.current_char     # => "a"
  *   s.pos              # => 0
  *
  */

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -342,6 +342,20 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 'a', s.curr_char
   end
 
+  def test_next_char
+    s = create_string_scanner('abc')
+    assert_equal 'a', s.curr_char
+    assert_equal 'b', s.next_char
+    assert_equal 'c', s.next_char
+    assert_equal 'c', s.curr_char
+    assert_equal nil, s.next_char
+
+    s = create_string_scanner("a\244\242".dup.force_encoding("euc-jp"))
+    assert_equal 'a', s.curr_char
+    assert_equal "\244\242".dup.force_encoding("euc-jp"), s.next_char
+    assert_equal nil, s.next_char
+  end
+
   def test_getch
     s = create_string_scanner('abcde')
     assert_equal 'a', s.getch

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -336,6 +336,15 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 1, s.skip(/^c/)
   end
 
+  def test_scan_upto
+    s = create_string_scanner("Fri Dec 12 1975 14:39")
+    assert_equal "Fri Dec ", s.scan_upto(/12 1975/)
+    assert_equal "Fri Dec ", s.pre_match
+    assert_equal '1',        s.curr_char
+    assert_equal '2',        s.next_char
+    assert_equal nil,        s.scan_upto(/XYZ/)
+  end
+
   def test_curr_char
     s = create_string_scanner('abcde')
     assert_equal 'a', s.curr_char

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -336,6 +336,12 @@ class TestStringScanner < Test::Unit::TestCase
     assert_equal 1, s.skip(/^c/)
   end
 
+  def test_curr_char
+    s = create_string_scanner('abcde')
+    assert_equal 'a', s.curr_char
+    assert_equal 'a', s.curr_char
+  end
+
   def test_getch
     s = create_string_scanner('abcde')
     assert_equal 'a', s.getch


### PR DESCRIPTION
This PR implements the three methods (`scan_upto`, `next_char`, and `curr_char`) as discussed in:

https://github.com/ruby/strscan/issues/50