### PR TITLE
Add test case to `test_string`

### DIFF
--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -155,8 +155,10 @@ class TestStringScanner < Test::Unit::TestCase
   end
 
   def test_string
-    s = create_string_scanner('test')
-    assert_equal 'test', s.string
+    s = create_string_scanner('test string')
+    assert_equal 'test string', s.string
+    s.scan(/test/)
+    assert_equal 'test string', s.string
     s.string = 'a'
     assert_equal 'a', s.string
     s.scan(/a/)


### PR DESCRIPTION
`string` returns the original string after `scan` is called. Current test doesn't check this behavior and now it's covered.