### PR TITLE
Fix a crash when `named_captures` called on new instance

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -829,6 +829,8 @@ public class RubyStringScanner extends RubyObject {
 
         RubyHash captures = RubyHash.newHash(runtime);
 
+        if (pattern == null) return captures;
+
         Iterator<NameEntry> nameEntryIterator = pattern.namedBackrefIterator();
 
         while (nameEntryIterator.hasNext()) {

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1502,7 +1502,9 @@ strscan_named_captures(VALUE self)
     named_captures_data data;
     data.self = self;
     data.captures = rb_hash_new();
-    onig_foreach_name(RREGEXP_PTR(p->regex), named_captures_iter, &data);
+    if (!RB_NIL_P(p->regex)) {
+        onig_foreach_name(RREGEXP_PTR(p->regex), named_captures_iter, &data);
+    }
 
     return data.captures;
 }

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -775,6 +775,7 @@ module StringScannerTests
   def test_named_captures
     omit("not implemented on TruffleRuby") if ["truffleruby"].include?(RUBY_ENGINE)
     scan = StringScanner.new("foobarbaz")
+    assert_equal({}, scan.named_captures)
     assert_equal(9, scan.match?(/(?<f>foo)(?<r>bar)(?<z>baz)/))
     assert_equal({"f" => "foo", "r" => "bar", "z" => "baz"}, scan.named_captures)
   end


### PR DESCRIPTION
```ruby
StringScanner.new('foo').named_captures
```

This commit fixes a crash in the case above.