### PR TITLE
Add .bundle to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /lib/*.jar
 /lib/*.so
 /lib/*.dylib
+/lib/*.bundle
 /pkg/
 /spec/reports/
 /tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /_yardoc/
 /coverage/
 /doc/
-/lib/*.{jar,so,dylib}
+/lib/*.jar
+/lib/*.so
+/lib/*.dylib
 /pkg/
 /spec/reports/
 /tmp/


### PR DESCRIPTION
I always ignore `lib/strscan.bundle` manually.