### PR TITLE
Fix crash when no scanning has been done

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1502,6 +1502,10 @@ strscan_named_captures(VALUE self)
     named_captures_data data;
     data.self = self;
     data.captures = rb_hash_new();
+    if (NIL_P(p->regex)) {
+        return data.captures;
+    }
+
     onig_foreach_name(RREGEXP_PTR(p->regex), named_captures_iter, &data);
 
     return data.captures;

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -778,6 +778,12 @@ module StringScannerTests
     assert_equal(9, scan.match?(/(?<f>foo)(?<r>bar)(?<z>baz)/))
     assert_equal({"f" => "foo", "r" => "bar", "z" => "baz"}, scan.named_captures)
   end
+
+  def test_named_captures_no_match
+    omit("not implemented on TruffleRuby") if ["truffleruby"].include?(RUBY_ENGINE)
+    scan = StringScanner.new("foobarbaz")
+    assert_equal({}, scan.named_captures)
+  end
 end
 
 class TestStringScanner < Test::Unit::TestCase


### PR DESCRIPTION
`StringScanner.new("foo").named_captures` will crash because no regular expression has been set.  This commit returns an empty hash if no re is set on the string scanner.

We could probably also return `nil`, but I'm not sure.  I think an empty hash is probably right since most callers expect a hash to be returned.