### PR TITLE
Use str encoding for empty rest string

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -770,7 +770,7 @@ public class RubyStringScanner extends RubyObject {
         int realSize = value.getRealSize();
 
         if (curr >= realSize) {
-            return RubyString.newEmptyString(runtime);
+            return RubyString.newEmptyString(runtime, str.getEncoding());
         }
 
         return extractRange(runtime, curr, realSize);


### PR DESCRIPTION
The empty string here should match the encoding of the scanner string.

Fixes #78