### PR TITLE
Clean up source-level warnings on Java 21

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -67,13 +67,14 @@ import static org.jruby.runtime.Visibility.PRIVATE;
  */
 @JRubyClass(name = "StringScanner")
 public class RubyStringScanner extends RubyObject {
+    private static final long serialVersionUID = -3722138049229128675L;
 
     private RubyString str;
     private int curr = 0;
     private int prev = -1;
 
-    private Region regs;
-    private Regex pattern;
+    private transient Region regs;
+    private transient Regex pattern;
     private boolean matched;
     private boolean fixedAnchor;
 
@@ -798,7 +799,7 @@ public class RubyStringScanner extends RubyObject {
     @JRubyMethod(name = "captures")
     public IRubyObject captures(ThreadContext context) {
         int i, numRegs;
-        RubyArray newAry;
+        RubyArray<?> newAry;
 
         if (!isMatched()) return context.nil;
 
@@ -825,7 +826,7 @@ public class RubyStringScanner extends RubyObject {
     @JRubyMethod(name = "values_at", rest = true)
     public IRubyObject values_at(ThreadContext context, IRubyObject[] args) {
         int i;
-        RubyArray newAry;
+        RubyArray<?> newAry;
 
         if (!isMatched()) return context.nil;
 


### PR DESCRIPTION
* RubyArray is generic and should be declared with <?> at minimum.
* The serialization changes are due to the RubyObject hierarchy implementing Serializable. Unfortunately the Joni classes are not themselves serializable, so these changes are solely to suppress the warnings.