### PR TITLE
Omit tests for `#scan_byte` and `#peek_byte` on TruffleRuby temporary

### DIFF
--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -9,6 +9,7 @@ require 'test/unit'
 
 module StringScannerTests
   def test_peek_byte
+    omit("not implemented on TruffleRuby") if RUBY_ENGINE == "truffleruby"
     s = create_string_scanner('ab')
     assert_equal 97, s.peek_byte
     assert_equal 97, s.scan_byte
@@ -19,6 +20,7 @@ module StringScannerTests
   end
 
   def test_scan_byte
+    omit("not implemented on TruffleRuby") if RUBY_ENGINE == "truffleruby"
     s = create_string_scanner('ab')
     assert_equal 97, s.scan_byte
     assert_equal 98, s.scan_byte


### PR DESCRIPTION
The methods were added in #89 but they aren't implemented in TruffleRuby yet. So let's skip them for now to have CI green.