### PR TITLE
Update Java ext version and add script logic for bump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,13 @@ namespace :version do
       "STRSCAN_VERSION \"#{version.succ}\""
     end
     File.write(strscan_c_path, strscan_c)
+
+    strscan_java_path = "ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java"
+    strscan_java = File.read(strscan_java_path).gsub(/STRSCAN_VERSION = "(.+?)"/) do
+      version = $1
+      "STRSCAN_VERSION = \"#{version.succ}\""
+    end
+    File.write(strscan_java_path, strscan_java)
   end
 end
 

--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -68,6 +68,8 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 public class RubyStringScanner extends RubyObject {
     private static final long serialVersionUID = -3722138049229128675L;
 
+    private static final String STRSCAN_VERSION = "3.1.0";
+
     private RubyString str;
     private int curr = 0;
     private int prev = -1;
@@ -88,7 +90,7 @@ public class RubyStringScanner extends RubyObject {
             Object.defineConstant("ScanError", error);
         }
 
-        RubyString version = runtime.newString("3.0.2");
+        RubyString version = runtime.newString(STRSCAN_VERSION);
         version.setFrozen(true);
         scannerClass.setConstant("Version", version);
         RubyString id = runtime.newString("$Id$");


### PR DESCRIPTION
The Java version is hardcoded like the C version, but has not been getting updated. This will at least let it be updated by the rake target version:bump, but any manual version number changes still have to be done to both the C code and the Java code.

Fixes #97

Note this also corrects the version to the last release, so when it is bumped again it should update.