### PR TITLE
[DOC] doc/strscan/strscan.md - fix triple backtick

### DIFF
--- a/doc/strscan/strscan.md
+++ b/doc/strscan/strscan.md
@@ -199,7 +199,8 @@ put_situation(scanner)
 #   pos:       8
 #   charpos:   6
 #   rest:      "んにちは"
-#   rest_size: 12```
+#   rest_size: 12
+```
 
 ## Target Substring
 


### PR DESCRIPTION
See current doc, search for '## Target Substring', notice the backtick that isn't visible to the GitHub md parser.

https://github.com/ruby/strscan/blob/843e931d134b0a8f0284296250454374e3f8a6aa/doc/strscan/strscan.md

Fixed in the PR, see:

https://github.com/MSP-Greg/strscan/blob/00-strscan.md/doc/strscan/strscan.md