### PR TITLE
Prevent a warning "ambiguous first argument" during a test

### DIFF
--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -905,7 +905,7 @@ module StringScannerTests
     assert_predicate s, :matched?
 
     s = create_string_scanner('-123abc')
-    assert_equal -123, s.scan_integer
+    assert_equal(-123, s.scan_integer)
     assert_equal 4, s.pos
     assert_predicate s, :matched?
 


### PR DESCRIPTION
https://rubyci.s3.amazonaws.com/debian11/ruby-master/log/20241128T153002Z.log.html.gz
```
/home/chkbuild/chkbuild/tmp/build/20241128T153002Z/ruby/test/strscan/test_stringscanner.rb:908: warning: ambiguous first argument; put parentheses or a space even after `-` operator
```