### PR TITLE
[DOC] Add syntax highlighting to MarkDown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ gem 'strscan'
 
 And then execute:
 
-    $ bundle
+```console
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install strscan
+```console
+$ gem install strscan
+```
 
 ## Usage
 

--- a/doc/strscan/helper_methods.md
+++ b/doc/strscan/helper_methods.md
@@ -10,7 +10,7 @@ Display scanner's situation:
 - Character position (`#charpos`)
 - Target string (`#rest`) and size (`#rest_size`).
 
-```
+```rb
 scanner = StringScanner.new('foobarbaz')
 scanner.scan(/foo/)
 put_situation(scanner)
@@ -25,7 +25,7 @@ put_situation(scanner)
 
 Display the scanner's match values:
 
-```
+```rb
 scanner = StringScanner.new('Fri Dec 12 1975 14:39')
 pattern = /(?<wday>\w+) (?<month>\w+) (?<day>\d+) /
 scanner.match?(pattern)
@@ -53,7 +53,7 @@ put_match_values(scanner)
 
 Returns whether the scanner's match values are all properly cleared:
 
-```
+```rb
 scanner = StringScanner.new('foobarbaz')
 match_values_cleared?(scanner) # => true
 put_match_values(scanner)
@@ -75,7 +75,7 @@ match_values_cleared?(scanner) # => false
 
 ## The Code
 
-```
+```rb
 def put_situation(scanner)
   puts '# Situation:'
   puts "#   pos:       #{scanner.pos}"
@@ -83,9 +83,7 @@ def put_situation(scanner)
   puts "#   rest:      #{scanner.rest.inspect}"
   puts "#   rest_size: #{scanner.rest_size}"
 end
-```
 
-```
 def put_match_values(scanner)
   puts '# Basic match values:'
   puts "#   matched?:       #{scanner.matched?}"
@@ -109,9 +107,7 @@ def put_match_values(scanner)
     end
   end
 end
-```
 
-```
 def match_values_cleared?(scanner)
   scanner.matched? == false &&
     scanner.matched_size.nil? &&

--- a/doc/strscan/methods/get_byte.md
+++ b/doc/strscan/methods/get_byte.md
@@ -10,7 +10,7 @@ Returns the next byte, if available:
     - Increments the [byte position][2].
     - Adjusts the [character position][7].
 
-    ```
+    ```rb
     scanner = StringScanner.new(HIRAGANA_TEXT)
     # => #<StringScanner 0/15 @ "\xE3\x81\x93\xE3\x82...">
     scanner.string                                   # => "こんにちは"
@@ -24,7 +24,7 @@ Returns the next byte, if available:
 
 - Otherwise, returns `nil`, and does not change the positions.
 
-    ```
+    ```rb
     scanner.terminate
     [scanner.get_byte, scanner.pos, scanner.charpos] # => [nil, 15, 5]
     ```

--- a/doc/strscan/methods/get_charpos.md
+++ b/doc/strscan/methods/get_charpos.md
@@ -5,7 +5,7 @@ Returns the [character position][7] (initially zero),
 which may be different from the [byte position][2]
 given by method #pos:
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string # => "こんにちは"
 scanner.getch  # => "こ" # 3-byte character.

--- a/doc/strscan/methods/get_pos.md
+++ b/doc/strscan/methods/get_pos.md
@@ -4,7 +4,7 @@ call-seq:
 Returns the integer [byte position][2],
 which may be different from the [character position][7]:
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string  # => "こんにちは"
 scanner.pos     # => 0

--- a/doc/strscan/methods/getch.md
+++ b/doc/strscan/methods/getch.md
@@ -12,7 +12,7 @@ if available:
     - Increments the [byte position][2]
       by the size (in bytes) of the character.
 
-    ```
+    ```rb
     scanner = StringScanner.new(HIRAGANA_TEXT)
     scanner.string                                # => "こんにちは"
     [scanner.getch, scanner.pos, scanner.charpos] # => ["こ", 3, 1]
@@ -27,7 +27,7 @@ if available:
   (that is, not at its beginning),
   behaves like #get_byte (returns a 1-byte character):
 
-    ```
+    ```rb
     scanner.pos = 1
     [scanner.getch, scanner.pos, scanner.charpos] # => ["\x81", 2, 2]
     [scanner.getch, scanner.pos, scanner.charpos] # => ["\x93", 3, 1]
@@ -37,7 +37,7 @@ if available:
 - If the [position][2] is at the end of the [stored string][1],
   returns `nil` and does not modify the positions:
 
-    ```
+    ```rb
     scanner.terminate
     [scanner.getch, scanner.pos, scanner.charpos] # => [nil, 15, 5]
     ```

--- a/doc/strscan/methods/scan.md
+++ b/doc/strscan/methods/scan.md
@@ -11,7 +11,7 @@ If the match succeeds:
   and may increment the [character position][7].
 - Sets [match values][9].
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string     # => "こんにちは"
 scanner.pos = 6
@@ -45,7 +45,7 @@ If the match fails:
 - Does not increment byte and character positions.
 - Clears match values.
 
-```
+```rb
 scanner.scan(/nope/)           # => nil
 match_values_cleared?(scanner) # => true
 ```

--- a/doc/strscan/methods/scan_until.md
+++ b/doc/strscan/methods/scan_until.md
@@ -12,7 +12,7 @@ If the match attempt succeeds:
 - Returns the matched substring.
 
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string           # => "こんにちは"
 scanner.pos = 6
@@ -46,7 +46,7 @@ If the match attempt fails:
 - Returns `nil`.
 - Does not update positions.
 
-```
+```rb
 scanner.scan_until(/nope/)     # => nil
 match_values_cleared?(scanner) # => true
 ```

--- a/doc/strscan/methods/set_pos.md
+++ b/doc/strscan/methods/set_pos.md
@@ -9,7 +9,7 @@ Does not affect [match values][9].
 
 For non-negative `n`, sets the position to `n`:
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string  # => "こんにちは"
 scanner.pos = 3 # => 3
@@ -19,7 +19,7 @@ scanner.charpos # => 1
 
 For negative `n`, counts from the end of the [stored string][1]:
 
-```
+```rb
 scanner.pos = -9 # => -9
 scanner.pos      # => 6
 scanner.rest     # => "にちは"

--- a/doc/strscan/methods/skip.md
+++ b/doc/strscan/methods/skip.md
@@ -11,7 +11,7 @@ If the match succeeds:
 - Sets [match values][9].
 - Returns the size (bytes) of the matched substring.
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string                  # => "こんにちは"
 scanner.pos = 6

--- a/doc/strscan/methods/skip_until.md
+++ b/doc/strscan/methods/skip_until.md
@@ -10,7 +10,7 @@ If the match attempt succeeds:
 - Sets [match values][9].
 - Returns the size of the matched substring.
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string           # => "こんにちは"
 scanner.pos = 6
@@ -43,7 +43,7 @@ If the match attempt fails:
 - Clears match values.
 - Returns `nil`.
 
-```
+```rb
 scanner.skip_until(/nope/)     # => nil
 match_values_cleared?(scanner) # => true
 ```

--- a/doc/strscan/methods/terminate.md
+++ b/doc/strscan/methods/terminate.md
@@ -7,7 +7,7 @@ returns +self+:
 - Sets both [positions][11] to end-of-stream.
 - Clears [match values][9].
 
-```
+```rb
 scanner = StringScanner.new(HIRAGANA_TEXT)
 scanner.string                 # => "こんにちは"
 scanner.scan_until(/に/)

--- a/doc/strscan/strscan.md
+++ b/doc/strscan/strscan.md
@@ -1,7 +1,7 @@
 \Class `StringScanner` supports processing a stored string as a stream;
 this code creates a new `StringScanner` object with string `'foobarbaz'`:
 
-```
+```rb
 require 'strscan'
 scanner = StringScanner.new('foobarbaz')
 ```
@@ -10,13 +10,13 @@ scanner = StringScanner.new('foobarbaz')
 
 All examples here assume that `StringScanner` has been required:
 
-```
+```rb
 require 'strscan'
 ```
 
 Some examples here assume that these constants are defined:
 
-```
+```rb
 MULTILINE_TEXT = <<~EOT
 Go placidly amid the noise and haste,
 and remember what peace there may be in silence.
@@ -45,7 +45,7 @@ This code creates a `StringScanner` object
 (we'll call it simply a _scanner_),
 and shows some of its basic properties:
 
-```
+```rb
 scanner = StringScanner.new('foobarbaz')
 scanner.string # => "foobarbaz"
 put_situation(scanner)
@@ -138,7 +138,7 @@ To get or set the byte position:
 Many methods use the byte position as the basis for finding matches;
 many others set, increment, or decrement the byte position:
 
-```
+```rb
 scanner = StringScanner.new('foobar')
 scanner.pos # => 0
 scanner.scan(/foo/) # => "foo" # Match found.
@@ -176,7 +176,7 @@ see:
 
 Example (string includes multi-byte characters):
 
-```
+```rb
 scanner = StringScanner.new(ENGLISH_TEXT) # Five 1-byte characters.
 scanner.concat(HIRAGANA_TEXT)             # Five 3-byte characters
 scanner.string # => "Helloこんにちは"       # Twenty bytes in all.
@@ -216,7 +216,7 @@ and its size is returned by method #rest_size.
 
 Examples:
 
-```
+```rb
 scanner = StringScanner.new('foobarbaz')
 put_situation(scanner)
 # Situation:
@@ -430,7 +430,7 @@ See examples below.
 
 Successful basic match attempt (no captures):
 
-```
+```rb
 scanner = StringScanner.new('foobarbaz')
 scanner.exist?(/bar/)
 put_match_values(scanner)
@@ -452,7 +452,7 @@ put_match_values(scanner)
 
 Failed basic match attempt (no captures);
 
-```
+```rb
 scanner = StringScanner.new('foobarbaz')
 scanner.exist?(/nope/)
 match_values_cleared?(scanner) # => true
@@ -460,7 +460,7 @@ match_values_cleared?(scanner) # => true
 
 Successful unnamed capture match attempt:
 
-```
+```rb
 scanner = StringScanner.new('foobarbazbatbam')
 scanner.exist?(/(foo)bar(baz)bat(bam)/)
 put_match_values(scanner)
@@ -486,7 +486,7 @@ put_match_values(scanner)
 Successful named capture match attempt;
 same as unnamed above, except for #named_captures:
 
-```
+```rb
 scanner = StringScanner.new('foobarbazbatbam')
 scanner.exist?(/(?<x>foo)bar(?<y>baz)bat(?<z>bam)/)
 scanner.named_captures # => {"x"=>"foo", "y"=>"baz", "z"=>"bam"}
@@ -494,7 +494,7 @@ scanner.named_captures # => {"x"=>"foo", "y"=>"baz", "z"=>"bam"}
 
 Failed unnamed capture match attempt:
 
-```
+```rb
 scanner = StringScanner.new('somestring')
 scanner.exist?(/(foo)bar(baz)bat(bam)/)
 match_values_cleared?(scanner) # => true
@@ -503,7 +503,7 @@ match_values_cleared?(scanner) # => true
 Failed named capture match attempt;
 same as unnamed above, except for #named_captures:
 
-```
+```rb
 scanner = StringScanner.new('somestring')
 scanner.exist?(/(?<x>foo)bar(?<y>baz)bat(?<z>bam)/)
 match_values_cleared?(scanner) # => false
@@ -518,7 +518,7 @@ which determines the meaning of `'\A'`:
 
 * `false` (the default): matches the current byte position.
 
-    ```
+    ```rb
     scanner = StringScanner.new('foobar')
     scanner.scan(/\A./) # => "f"
     scanner.scan(/\A./) # => "o"
@@ -529,7 +529,7 @@ which determines the meaning of `'\A'`:
 * `true`: matches the beginning of the target substring;
   never matches unless the byte position is zero:
 
-    ```
+    ```rb
     scanner = StringScanner.new('foobar', fixed_anchor: true)
     scanner.scan(/\A./) # => "f"
     scanner.scan(/\A./) # => nil

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -231,7 +231,7 @@ strscan_s_allocate(VALUE klass)
  * is the given `string`;
  * sets the [fixed-anchor property][10]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.string        # => "foobarbaz"
  * scanner.fixed_anchor? # => false
@@ -339,7 +339,7 @@ strscan_s_mustc(VALUE self)
  * and clears [match values][9];
  * returns +self+:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.exist?(/bar/)          # => 6
  * scanner.reset                  # => #<StringScanner 0/9 @ "fooba...">
@@ -405,7 +405,7 @@ strscan_clear(VALUE self)
  *
  * Returns the [stored string][1]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobar')
  * scanner.string # => "foobar"
  * scanner.concat('baz')
@@ -435,7 +435,7 @@ strscan_get_string(VALUE self)
  * - Clears [match values][9].
  * - Returns `other_string`.
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobar')
  * scanner.scan(/foo/)
  * put_situation(scanner)
@@ -483,7 +483,7 @@ strscan_set_string(VALUE self, VALUE str)
  *   or [match values][9].
  *
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foo')
  * scanner.string           # => "foo"
  * scanner.terminate
@@ -789,7 +789,7 @@ strscan_scan(VALUE self, VALUE re)
  * - Returns the size in bytes of the matched substring.
  *
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.pos = 3
  * scanner.match?(/bar/) => 3
@@ -822,7 +822,7 @@ strscan_scan(VALUE self, VALUE re)
  * - Returns `nil`.
  * - Does not increment positions.
  *
- * ```
+ * ```rb
  * scanner.match?(/nope/)         # => nil
  * match_values_cleared?(scanner) # => true
  * ```
@@ -861,7 +861,7 @@ strscan_skip(VALUE self, VALUE re)
  * - Returns the matched substring.
  * - Sets all [match values][9].
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.pos = 3
  * scanner.check('bar') # => "bar"
@@ -894,7 +894,7 @@ strscan_skip(VALUE self, VALUE re)
  * - Returns `nil`.
  * - Clears all [match values][9].
  *
- * ```
+ * ```rb
  * scanner.check(/nope/)          # => nil
  * match_values_cleared?(scanner) # => true
  * ```
@@ -961,7 +961,7 @@ strscan_scan_until(VALUE self, VALUE re)
  *   and the end of the matched substring.
  * - Sets all [match values][9].
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbazbatbam')
  * scanner.pos = 6
  * scanner.exist?(/bat/) # => 6
@@ -993,7 +993,7 @@ strscan_scan_until(VALUE self, VALUE re)
  * - Returns `nil`.
  * - Clears all [match values][9].
  *
- * ```
+ * ```rb
  * scanner.exist?(/nope/)         # => nil
  * match_values_cleared?(scanner) # => true
  * ```
@@ -1035,7 +1035,7 @@ strscan_skip_until(VALUE self, VALUE re)
  *   which extends from the current [position][2]
  *   to the end of the matched substring.
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbazbatbam')
  * scanner.pos = 6
  * scanner.check_until(/bat/) # => "bazbat"
@@ -1067,7 +1067,7 @@ strscan_skip_until(VALUE self, VALUE re)
  * - Clears all [match values][9].
  * - Returns `nil`.
  *
- * ```
+ * ```rb
  * scanner.check_until(/nope/)    # => nil
  * match_values_cleared?(scanner) # => true
  * ```
@@ -1239,7 +1239,7 @@ strscan_getbyte(VALUE self)
  * Returns the substring `string[pos, length]`;
  * does not update [match values][9] or [positions][11]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.pos = 3
  * scanner.peek(3)   # => "bar"
@@ -1403,7 +1403,7 @@ strscan_scan_base16_integer(VALUE self)
  * Sets the [position][2] to its value previous to the recent successful
  * [match][17] attempt:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.scan(/foo/)
  * put_situation(scanner)
@@ -1424,7 +1424,7 @@ strscan_scan_base16_integer(VALUE self)
  *
  * Raises an exception if match values are clear:
  *
- * ```
+ * ```rb
  * scanner.scan(/nope/)           # => nil
  * match_values_cleared?(scanner) # => true
  * scanner.unscan                 # Raises StringScanner::Error.
@@ -1498,7 +1498,7 @@ strscan_bol_p(VALUE self)
  * Returns whether the [position][2]
  * is at the end of the [stored string][1]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.eos? # => false
  * pos = 3
@@ -1567,7 +1567,7 @@ strscan_rest_p(VALUE self)
  * `false` otherwise;
  * see [Basic Matched Values][18]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.matched?       # => false
  * scanner.pos = 3
@@ -1599,7 +1599,7 @@ strscan_matched_p(VALUE self)
  * or `nil` otherwise;
  * see [Basic Matched Values][18]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.matched        # => nil
  * scanner.pos = 3
@@ -1634,7 +1634,7 @@ strscan_matched(VALUE self)
  * or `nil` otherwise;
  * see [Basic Matched Values][18]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.matched_size   # => nil
  *
@@ -1688,14 +1688,14 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
  *
  * When there are captures:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('Fri Dec 12 1975 14:39')
  * scanner.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+) /)
  * ```
  *
  * - `specifier` zero: returns the entire matched substring:
  *
- *     ```
+ *     ```rb
  *     scanner[0]         # => "Fri Dec 12 "
  *     scanner.pre_match  # => ""
  *     scanner.post_match # => "1975 14:39"
@@ -1703,7 +1703,7 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
  *
  * - `specifier` positive integer. returns the `n`th capture, or `nil` if out of range:
  *
- *     ```
+ *     ```rb
  *     scanner[1] # => "Fri"
  *     scanner[2] # => "Dec"
  *     scanner[3] # => "12"
@@ -1712,7 +1712,7 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
  *
  * - `specifier` negative integer. counts backward from the last subgroup:
  *
- *     ```
+ *     ```rb
  *     scanner[-1] # => "12"
  *     scanner[-4] # => "Fri Dec 12 "
  *     scanner[-5] # => nil
@@ -1720,7 +1720,7 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
  *
  * - `specifier` symbol or string. returns the named subgroup, or `nil` if no such:
  *
- *     ```
+ *     ```rb
  *     scanner[:wday]  # => "Fri"
  *     scanner['wday'] # => "Fri"
  *     scanner[:month] # => "Dec"
@@ -1730,7 +1730,7 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
  *
  * When there are no captures, only `[0]` returns non-`nil`:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.exist?(/bar/)
  * scanner[0] # => "bar"
@@ -1739,7 +1739,7 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
  *
  * For a failed match, even `[0]` returns `nil`:
  *
- * ```
+ * ```rb
  * scanner.scan(/nope/) # => nil
  * scanner[0]           # => nil
  * scanner[1]           # => nil
@@ -1790,7 +1790,7 @@ strscan_aref(VALUE self, VALUE idx)
  * Returns the count of captures if the most recent match attempt succeeded, `nil` otherwise;
  * see [Captures Match Values][13]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('Fri Dec 12 1975 14:39')
  * scanner.size                        # => nil
  *
@@ -1824,7 +1824,7 @@ strscan_size(VALUE self)
  * Returns the array of [captured match values][13] at indexes `(1..)`
  * if the most recent match attempt succeeded, or `nil` otherwise:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('Fri Dec 12 1975 14:39')
  * scanner.captures         # => nil
  *
@@ -1879,7 +1879,7 @@ strscan_captures(VALUE self)
  * For each `specifier`, the returned substring is `[specifier]`;
  * see #[].
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('Fri Dec 12 1975 14:39')
  * pattern = /(?<wday>\w+) (?<month>\w+) (?<day>\d+) /
  * scanner.match?(pattern)
@@ -1919,7 +1919,7 @@ strscan_values_at(int argc, VALUE *argv, VALUE self)
  * or `nil` otherwise;
  * see [Basic Match Values][18]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.pre_match      # => nil
  *
@@ -1956,7 +1956,7 @@ strscan_pre_match(VALUE self)
  * or `nil` otherwise;
  * see [Basic Match Values][18]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.post_match     # => nil
  *
@@ -1991,7 +1991,7 @@ strscan_post_match(VALUE self)
  * Returns the 'rest' of the [stored string][1] (all after the current [position][2]),
  * which is the [target substring][3]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.rest # => "foobarbaz"
  * scanner.pos = 3
@@ -2022,7 +2022,7 @@ strscan_rest(VALUE self)
  *
  * Returns the size (in bytes) of the #rest of the [stored string][1]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('foobarbaz')
  * scanner.rest      # => "foobarbaz"
  * scanner.rest_size # => 9
@@ -2081,7 +2081,7 @@ strscan_restsize(VALUE self)
  * 3. The substring preceding the current position.
  * 4. The substring following the current position (which is also the [target substring][3]).
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new("Fri Dec 12 1975 14:39")
  * scanner.pos = 11
  * scanner.inspect # => "#<StringScanner 11/21 \"...c 12 \" @ \"1975 ...\">"
@@ -2089,14 +2089,14 @@ strscan_restsize(VALUE self)
  *
  * If at beginning-of-string, item 4 above (following substring) is omitted:
  *
- * ```
+ * ```rb
  * scanner.reset
  * scanner.inspect # => "#<StringScanner 0/21 @ \"Fri D...\">"
  * ```
  *
  * If at end-of-string, all items above are omitted:
  *
- * ```
+ * ```rb
  * scanner.terminate
  * scanner.inspect # => "#<StringScanner fin>"
  * ```
@@ -2224,7 +2224,7 @@ named_captures_iter(const OnigUChar *name,
  * if the most recent match attempt succeeded, or nil otherwise;
  * see [Captured Match Values][13]:
  *
- * ```
+ * ```rb
  * scanner = StringScanner.new('Fri Dec 12 1975 14:39')
  * scanner.named_captures # => {}
  *


### PR DESCRIPTION
Split off from https://github.com/ruby/ruby/pull/12322