### PR TITLE
Re-port new integer-scanning utility methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
 - push
 - pull_request
 
+env:
+  JRUBY_OPTS: "-X+C" # temporarily force JRuby to compile, so Java exception trace will contain .rb lines
+
 jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master

--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -39,6 +39,7 @@ import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyHash;
+import org.jruby.RubyInteger;
 import org.jruby.RubyMatchData;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
@@ -590,9 +591,7 @@ public class RubyStringScanner extends RubyObject {
             len++;
         }
 
-        this.curr = ptr + len;
-
-        return ConvertBytes.byteListToInum(runtime, bytes, 0, len, 10, true);
+        return strscanParseInteger(runtime, bytes, ptr, len, 10);
     }
 
     @JRubyMethod(name = "scan_base16_integer", visibility = PRIVATE)
@@ -634,9 +633,13 @@ public class RubyStringScanner extends RubyObject {
             len++;
         }
 
+        return strscanParseInteger(runtime, bytes, ptr, len, 16);
+    }
+
+    private RubyInteger strscanParseInteger(Ruby runtime, ByteList bytes, int ptr, int len, int base) {
         this.curr = ptr + len;
 
-        return ConvertBytes.byteListToInum(runtime, bytes, 0, len, 16, true);
+        return ConvertBytes.byteListToInum(runtime, bytes, ptr, len, base, true);
     }
 
     private void strscanMustAsciiCompat(Ruby runtime) {


### PR DESCRIPTION
This is a re-port of the C code from @byroot for fast base 10 and base 16 integer scanning.

In https://github.com/ruby/strscan/issues/125, @kou pointed out there's an intermittent failure in the JRuby extension. We were unable to confirm exactly the circumstances that cause that failure, but this re-port should at least help reduce the change it is a bug in the original Java code.