### PR TITLE
`scan_integer(base: 16)` ignore x suffix if not followed by hexadecimal

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -616,7 +616,10 @@ public class RubyStringScanner extends RubyObject {
             len++;
         }
 
-        if ((remaining_len >= (len + 2)) && bytes.get(ptr + len) == '0' && bytes.get(ptr + len + 1) == 'x') {
+        if ((remaining_len >= (len + 3)) &&
+                bytes.get(ptr + len) == '0' &&
+                bytes.get(ptr + len + 1) == 'x' &&
+                isHexChar(bytes.get(ptr + len + 2))) {
             len += 2;
         }
 

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1379,7 +1379,7 @@ strscan_scan_base16_integer(VALUE self)
         len++;
     }
 
-    if ((remaining_len >= (len + 2)) && ptr[len] == '0' && ptr[len + 1] == 'x') {
+    if ((remaining_len >= (len + 3)) && ptr[len] == '0' && ptr[len + 1] == 'x' && rb_isxdigit(ptr[len + 2])) {
         len += 2;
     }
 

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1052,19 +1052,24 @@ module StringScannerTests
     assert_predicate(s, :matched?)
 
     s = create_string_scanner('0x')
-    assert_nil(s.scan_integer(base: 16))
-    assert_equal(0, s.pos)
-    refute_predicate(s, :matched?)
+    assert_equal(0, s.scan_integer(base: 16))
+    assert_equal(1, s.pos)
+    assert_predicate(s, :matched?)
+
+    s = create_string_scanner('0xyz')
+    assert_equal(0, s.scan_integer(base: 16))
+    assert_equal(1, s.pos)
+    assert_predicate(s, :matched?)
 
     s = create_string_scanner('-0x')
-    assert_nil(s.scan_integer(base: 16))
-    assert_equal(0, s.pos)
-    refute_predicate(s, :matched?)
+    assert_equal(0, s.scan_integer(base: 16))
+    assert_equal(2, s.pos)
+    assert_predicate(s, :matched?)
 
     s = create_string_scanner('+0x')
-    assert_nil(s.scan_integer(base: 16))
-    assert_equal(0, s.pos)
-    refute_predicate(s, :matched?)
+    assert_equal(0, s.scan_integer(base: 16))
+    assert_equal(2, s.pos)
+    assert_predicate(s, :matched?)
 
     s = create_string_scanner('-123abc')
     assert_equal(-0x123abc, s.scan_integer(base: 16))


### PR DESCRIPTION
Fix: https://github.com/ruby/strscan/issues/140

`0x<EOF>`, `0xZZZ` should be parsed as `0` instead of not matching at all.