### PR TITLE
Pass end index to byteListToInum

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -651,7 +651,7 @@ public class RubyStringScanner extends RubyObject {
         setMatched();
         adjustRegisters();
 
-        return ConvertBytes.byteListToInum(runtime, bytes, ptr, len, base, true);
+        return ConvertBytes.byteListToInum(runtime, bytes, ptr, ptr + len, base, true);
     }
 
     private void strscanMustAsciiCompat(Ruby runtime) {

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1006,6 +1006,12 @@ module StringScannerTests
     assert_equal(huge_integer.to_i, s.scan_integer)
     assert_equal(2_000, s.pos)
     assert_predicate(s, :matched?)
+
+    s = create_string_scanner('abc1')
+    s.pos = 3
+    assert_equal(1, s.scan_integer)
+    assert_equal(4, s.pos)
+    assert_predicate(s, :matched?)
   end
 
   def test_scan_integer_unmatch


### PR DESCRIPTION
These parse methods take begin and end indices, not begin and length. A test is included.

Fixes https://github.com/jruby/jruby/issues/8823