### PR TITLE
Fix JRuby CI for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           distribution: zulu
           java-version: 21
         if: >-
-          matrix.ruby == 'jruby-head'
+          startsWith(matrix.ruby, 'jruby')
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The setup-ruby logic for JRuby on Windows must not be fully choosing Java 21, so when it tries to compile the extension it's still using an older version. This fixes it.