### PR TITLE
jruby: Check if len++ walked off the end

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -589,7 +589,7 @@ public class RubyStringScanner extends RubyObject {
             len++;
         }
 
-        if (!Character.isDigit(bytes.get(ptr + len))) {
+        if (len >= remaining_len || !Character.isDigit(bytes.get(ptr + len))) {
             return context.nil;
         }
 

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1001,6 +1001,16 @@ module StringScannerTests
     assert_equal(0, s.pos)
     refute_predicate(s, :matched?)
 
+    s = create_string_scanner('-')
+    assert_nil(s.scan_integer)
+    assert_equal(0, s.pos)
+    refute_predicate(s, :matched?)
+
+    s = create_string_scanner('+')
+    assert_nil(s.scan_integer)
+    assert_equal(0, s.pos)
+    refute_predicate(s, :matched?)
+
     huge_integer = '1' * 2_000
     s = create_string_scanner(huge_integer)
     assert_equal(huge_integer.to_i, s.scan_integer)


### PR DESCRIPTION
Fix GH-152

CRuby can walk off the end because there's always a null byte. In JRuby, the byte array is often (usually?) the exact size of the string. So we need to check if len++ walked off the end.

This code was ported from a version by @byroot in https://github.com/ruby/strscan/pull/127 but I missed adding this check due to a lack of tests. A test is included for both "-" and "+" parsing.