### PR TITLE
Update extconf.rb

### DIFF
--- a/ext/strscan/extconf.rb
+++ b/ext/strscan/extconf.rb
@@ -2,8 +2,8 @@
 require 'mkmf'
 if RUBY_ENGINE == 'ruby'
   $INCFLAGS << " -I$(top_srcdir)" if $extmk
-  have_func("onig_region_memsize", "ruby.h")
-  have_func("rb_reg_onig_match", "ruby.h")
+  have_func("onig_region_memsize")
+  have_func("rb_reg_onig_match", "ruby/re.h")
   create_makefile 'strscan'
 else
   File.write('Makefile', dummy_makefile("").join)


### PR DESCRIPTION
- `have_func` includes "ruby.h" by default.
- include "ruby/re.h" where `rb_reg_onig_match` is declared.