### PR TITLE
Remove no longer used variable

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -30,7 +30,6 @@ extern size_t onig_region_memsize(const struct re_registers *regs);
 
 static VALUE StringScanner;
 static VALUE ScanError;
-static ID id_byteslice;
 
 static int usascii_encindex, utf8_encindex, binary_encindex;
 
@@ -2286,8 +2285,6 @@ Init_strscan(void)
 #undef rb_intern
     ID id_scanerr = rb_intern("ScanError");
     VALUE tmp;
-
-    id_byteslice = rb_intern("byteslice");
 
     usascii_encindex = rb_usascii_encindex();
     utf8_encindex = rb_utf8_encindex();


### PR DESCRIPTION
Since ruby/strscan@92961cde2b421cd64b66af4079be8c796fdb89eb.
ruby/strscan#20.