### PR TITLE
Deprecate constant `Id`

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -100,6 +100,7 @@ public class RubyStringScanner extends RubyObject {
         RubyString id = runtime.newString("$Id$");
         id.setFrozen(true);
         scannerClass.setConstant(context, "Id", id);
+        scannerClass.deprecateConstant(context, "Id");
 
         scannerClass.defineAnnotatedMethods(RubyStringScanner.class);
 

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -2226,6 +2226,7 @@ Init_strscan(void)
     tmp = rb_str_new2("$Id$");
     rb_obj_freeze(tmp);
     rb_const_set(StringScanner, rb_intern("Id"), tmp);
+    rb_deprecate_constant(StringScanner, "Id");
 
     rb_define_alloc_func(StringScanner, strscan_s_allocate);
     rb_define_private_method(StringScanner, "initialize", strscan_initialize, -1);

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -107,11 +107,6 @@ module StringScannerTests
     assert_equal(true, StringScanner::Version.frozen?)
   end
 
-  def test_const_Id
-    assert_instance_of(String, StringScanner::Id)
-    assert_equal(true, StringScanner::Id.frozen?)
-  end
-
   def test_inspect
     str = 'test string'.dup
     s = create_string_scanner(str, false)


### PR DESCRIPTION
`$Id$` is for RCS, CVS, and SVN; no information with GIT.