### PR TITLE
[DOC] Fix broken link to helper methods

### DIFF
--- a/doc/strscan/strscan.md
+++ b/doc/strscan/strscan.md
@@ -37,7 +37,7 @@ Some examples here assume that certain helper methods are defined:
 - `match_values_cleared?(scanner)`:
   Returns whether the scanner's [match values][9] are cleared.
 
-See examples at [helper methods](doc/strscan/helper_methods.md).
+See examples at [helper methods](helper_methods.md).
 
 ## The `StringScanner` \Object
 


### PR DESCRIPTION
### Helper methods link is broken at master branch

To reproduce
1. go to [StringScanner docs](https://docs.ruby-lang.org/en/master/StringScanner.html) 
2. Click to link at line 
   > See examples at **helper_methods**
3. Resolved url gives 404: https://docs.ruby-lang.org/en/master/strscan/helper_methods_md.html

### Fix

Currently link resolves as `href="doc/strscan/helper_methods_md.html"`
Correct link should be resolved as `href="helper_methods_md.html"`
