### PR TITLE
[DOC] Avoid being interpreted as a link

### DIFF
--- a/doc/strscan/strscan.md
+++ b/doc/strscan/strscan.md
@@ -417,7 +417,7 @@ Each of these methods returns a captured match value:
 | Method          | Return After Match                      | Return After No Match |
 |-----------------|-----------------------------------------|-----------------------|
 | #size           | Count of captured substrings.           | +nil+.                |
-| #[](n)          | <tt>n</tt>th captured substring.        | +nil+.                |
+| #\[\](n)        | <tt>n</tt>th captured substring.        | +nil+.                |
 | #captures       | Array of all captured substrings.       | +nil+.                |
 | #values_at(*n)  | Array of specified captured substrings. | +nil+.                |
 | #named_captures | Hash of named captures.                 | <tt>{}</tt>.          |


### PR DESCRIPTION
Since `[](n)` is being interpreted as a Markdown link, it cannot be displayed as a method call.
I have corrected this by escaping the brackets so that they are interpreted as strings rather than links.

### Before

ri

```
    #{}[n]     |   <tt>n</tt>th captured substring.    |       +nil+.
```

html

<img width="424" height="217" alt="image" src="https://github.com/user-attachments/assets/b45601ab-ed1c-4b82-b112-325f12bde197" />

### After

ri

```
    #[](n)     |   <tt>n</tt>th captured substring.    |       +nil+.
```

html

<img width="489" height="217" alt="image" src="https://github.com/user-attachments/assets/1212c147-42a5-4f62-8667-a279ccff67a3" />
