### PR TITLE
retain code-range upon string extraction + align with strscan.c

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -947,7 +947,23 @@ public class RubyStringScanner extends RubyObject {
     private RubyString newString(Ruby runtime, int start, int length) {
         final ByteList strBytes = this.str.getByteList();
         ByteList newBytes = new ByteList(strBytes.unsafeBytes(), strBytes.begin() + start, length, true);
-        return RubyString.newString(runtime, newBytes, strBytes.getEncoding());
+
+        final RubyString newStr = RubyString.newString(runtime, newBytes, strBytes.getEncoding());
+        copyCodeRangeForSubstr(newStr, this.str);
+        return newStr;
+    }
+
+    /**
+     * Same as JRuby's (private) <code>RubyString#copyCodeRangeForSubstr</code>.
+     * Isn't really necessary, but will avoid extra code-range scans for the substrings returned.
+     */
+    private void copyCodeRangeForSubstr(RubyString str, RubyString from) {
+        if (str.size() == 0) {
+            str.setCodeRange(from.getEncoding().isAsciiCompatible() ? StringSupport.CR_7BIT : StringSupport.CR_VALID);
+        } else {
+            if (from.getCodeRange() == StringSupport.CR_7BIT) str.setCodeRange(StringSupport.CR_7BIT);
+            // otherwise, leave it as CR_UNKNOWN
+        }
     }
 
     /**


### PR DESCRIPTION
added an extra step upon creating a substring from `scanner.string` -> retaining code-range when possible

also, there was an attempt to raise `"regexp buffer overflow"` upon `Matcher.INTERRUPTED` (-2), which isn't possible as the `RubyRegexp#matcherMatch/matcherSearch`  [handle the interrupt return](https://github.com/jruby/jruby/blob/10.0.2.0/core/src/main/java/org/jruby/RubyRegexp.java#L236-L257).

a follow-up on https://github.com/ruby/strscan/pull/185