### PR TITLE
ci: Don't run a job for Ruby 2.5 on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - { os: ubuntu-latest , ruby: jruby-9.4 }
         exclude:
           - { os: macos-latest , ruby: 2.4 }
+          - { os: ubuntu-latest , ruby: 2.5 }
           - { os: macos-latest , ruby: 2.5 }
           - { os: windows-latest , ruby: head }
           - { os: ubuntu-latest , ruby: truffleruby }


### PR DESCRIPTION
GitHub: fix GH-187

RubyGems 2.7.6 and psych 5.3.0+ don't work. We don't maintain the combination (e.g. pining psych to 5.2.6).

So let's remove the job.

Reported by Charles Oliver Nutter. Thanks!!!