### PR TITLE
[Feature #21943] Add `StringScanner#integer_at`

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1887,14 +1887,14 @@ parse_decimal_fast(const char *ptr, long len)
 
     /* Validate: only digits and underscores (not leading/trailing/consecutive) */
     {
-        long k;
+        long i;
         bool prev_underscore = true; /* treat start as underscore to reject leading _ */
-        for (k = digits_start; k < len; k++) {
-            if (ptr[k] >= '0' && ptr[k] <= '9') {
+        for (i = digits_start; i < len; i++) {
+            if (ptr[i] >= '0' && ptr[i] <= '9') {
                 digit_count++;
                 prev_underscore = false;
             }
-            else if (ptr[k] == '_' && !prev_underscore) {
+            else if (ptr[i] == '_' && !prev_underscore) {
                 prev_underscore = true;
             }
             else {
@@ -1911,19 +1911,19 @@ parse_decimal_fast(const char *ptr, long len)
     {
         long first_nonzero = digits_start;
         long effective_digits;
-        long k;
+        long i;
         while (first_nonzero < len && (ptr[first_nonzero] == '0' || ptr[first_nonzero] == '_'))
             first_nonzero++;
         effective_digits = 0;
-        for (k = first_nonzero; k < len; k++) {
-            if (ptr[k] != '_') effective_digits++;
+        for (i = first_nonzero; i < len; i++) {
+            if (ptr[i] != '_') effective_digits++;
         }
 
         if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS : INT32_DECIMAL_SAFE_DIGITS)) {
             long result = 0;
-            for (k = first_nonzero; k < len; k++) {
-                if (ptr[k] != '_')
-                    result = result * 10 + (ptr[k] - '0');
+            for (i = first_nonzero; i < len; i++) {
+                if (ptr[i] != '_')
+                    result = result * 10 + (ptr[i] - '0');
             }
             if (negative) result = -result;
             return LONG2NUM(result);
@@ -1935,9 +1935,9 @@ parse_decimal_fast(const char *ptr, long len)
                 ? (unsigned long)LONG_MAX + 1
                 : (unsigned long)LONG_MAX;
             bool overflow = false;
-            for (k = first_nonzero; k < len; k++) {
-                if (ptr[k] != '_') {
-                    unsigned long d = ptr[k] - '0';
+            for (i = first_nonzero; i < len; i++) {
+                if (ptr[i] != '_') {
+                    unsigned long d = ptr[i] - '0';
                     /* Pre-check before multiply to avoid unsigned long wraparound on
                      * 32-bit platforms, where 10-digit values can exceed ULONG_MAX. */
                     if (result > (limit - d) / 10) {

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1919,19 +1919,19 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
      * This covers the Date._strptime use case. */
     if (base == 10) {
         long j = 0;
-        int negative = 0;
+        bool negative = false;
         long digit_count;
 
-        if (ptr[0] == '-') { negative = 1; j = 1; }
+        if (ptr[0] == '-') { negative = true; j = 1; }
         else if (ptr[0] == '+') { j = 1; }
 
         digit_count = len - j;
         if (digit_count > 0) {
             long k;
-            int all_digits = 1;
+            bool all_digits = true;
             for (k = j; k < len; k++) {
                 if (ptr[k] < '0' || ptr[k] > '9') {
-                    all_digits = 0;
+                    all_digits = false;
                     break;
                 }
             }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1997,11 +1997,12 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
     long i;
     long beg, end, len;
     const char *ptr;
-    VALUE specifier, vbase;
+    VALUE specifier;
     int base = 10;
 
-    rb_scan_args(argc, argv, "11", &specifier, &vbase);
-    if (!NIL_P(vbase)) base = NUM2INT(vbase);
+    rb_check_arity(argc, 1, 2);
+    specifier = argv[0];
+    if (argc > 1) base = NUM2INT(argv[1]);
 
     GET_SCANNER(self, p);
     i = resolve_capture_index(p, specifier);

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1621,6 +1621,37 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
                  rb_long2int(name_end - name), name);
 }
 
+/* Resolve capture group index from Integer, Symbol, or String.
+ * Returns the resolved register index, or -1 if unmatched/out of range. */
+static long
+resolve_capture_index(struct strscanner *p, VALUE idx)
+{
+    const char *name;
+    long i;
+
+    if (! MATCHED_P(p)) return -1;
+
+    switch (TYPE(idx)) {
+        case T_SYMBOL:
+            idx = rb_sym2str(idx);
+            /* fall through */
+        case T_STRING:
+            RSTRING_GETMEM(idx, name, i);
+            i = name_to_backref_number(&(p->regs), p->regex, name, name + i, rb_enc_get(idx));
+            break;
+        default:
+            i = NUM2LONG(idx);
+    }
+
+    if (i < 0)
+        i += p->regs.num_regs;
+    if (i < 0)                 return -1;
+    if (i >= p->regs.num_regs) return -1;
+    if (p->regs.beg[i] == -1)  return -1;
+
+    return i;
+}
+
 /*
  *
  * :markup: markdown
@@ -1695,30 +1726,12 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
 static VALUE
 strscan_aref(VALUE self, VALUE idx)
 {
-    const char *name;
     struct strscanner *p;
     long i;
 
     GET_SCANNER(self, p);
-    if (! MATCHED_P(p))        return Qnil;
-
-    switch (TYPE(idx)) {
-        case T_SYMBOL:
-            idx = rb_sym2str(idx);
-            /* fall through */
-        case T_STRING:
-            RSTRING_GETMEM(idx, name, i);
-            i = name_to_backref_number(&(p->regs), p->regex, name, name + i, rb_enc_get(idx));
-            break;
-        default:
-            i = NUM2LONG(idx);
-    }
-
-    if (i < 0)
-        i += p->regs.num_regs;
-    if (i < 0)                 return Qnil;
-    if (i >= p->regs.num_regs) return Qnil;
-    if (p->regs.beg[i] == -1)  return Qnil;
+    i = resolve_capture_index(p, idx);
+    if (i < 0) return Qnil;
 
     return extract_range(p,
                          adjust_register_position(p, p->regs.beg[i]),
@@ -1850,6 +1863,60 @@ strscan_values_at(int argc, VALUE *argv, VALUE self)
     }
 
     return new_ary;
+}
+
+/*
+ * call-seq:
+ *   integer_at(index, base = 10) -> integer or nil
+ *
+ * Returns the captured substring at the given +index+ as an Integer,
+ * following the behavior of <tt>String#to_i(base)</tt>.
+ *
+ * +index+ can be an Integer (positive, negative, or zero), a Symbol,
+ * or a String for named capture groups.
+ *
+ * Returns +nil+ if:
+ * - No match has been performed or the last match failed
+ * - The +index+ is out of range
+ * - The group at +index+ did not participate in the match
+ *
+ * This is semantically equivalent to <tt>self[index].to_i(base)</tt>
+ * but avoids the allocation of a temporary String when possible.
+ *
+ *   scanner = StringScanner.new("2024-06-15")
+ *   scanner.scan(/(\d{4})-(\d{2})-(\d{2})/)
+ *   scanner.integer_at(1)       # => 2024
+ *   scanner.integer_at(1, 16)   # => 8228
+ *
+ */
+static VALUE
+strscan_integer_at(int argc, VALUE *argv, VALUE self)
+{
+    struct strscanner *p;
+    long i;
+    long beg, end, len;
+    const char *ptr;
+    VALUE idx, vbase;
+    int base = 10;
+
+    rb_scan_args(argc, argv, "11", &idx, &vbase);
+    if (!NIL_P(vbase)) base = NUM2INT(vbase);
+
+    GET_SCANNER(self, p);
+    i = resolve_capture_index(p, idx);
+    if (i < 0) return Qnil;
+
+    beg = adjust_register_position(p, p->regs.beg[i]);
+    end = adjust_register_position(p, p->regs.end[i]);
+    len = end - beg;
+
+    if (len <= 0) return INT2FIX(0);
+
+    ptr = S_PBEG(p) + beg;
+
+    /* Follow String#to_i(base) semantics via rb_str_to_inum.
+     * badcheck=0 returns 0 for non-numeric input instead of raising. */
+    return rb_str_to_inum(rb_str_new(ptr, len), base, 0);
 }
 
 /*
@@ -2290,6 +2357,7 @@ Init_strscan(void)
     rb_define_method(StringScanner, "size",        strscan_size,        0);
     rb_define_method(StringScanner, "captures",    strscan_captures,    0);
     rb_define_method(StringScanner, "values_at",   strscan_values_at,  -1);
+    rb_define_method(StringScanner, "integer_at",  strscan_integer_at, -1);
 
     rb_define_method(StringScanner, "rest",        strscan_rest,        0);
     rb_define_method(StringScanner, "rest_size",   strscan_rest_size,   0);

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1867,20 +1867,20 @@ strscan_values_at(int argc, VALUE *argv, VALUE self)
 
 /*
  * call-seq:
- *   integer_at(index, base = 10) -> integer or nil
+ *   integer_at(specifier, base = 10) -> integer or nil
  *
- * Returns the captured substring at the given +index+ as an Integer,
+ * Returns the captured substring at the given +specifier+ as an Integer,
  * following the behavior of <tt>String#to_i(base)</tt>.
  *
- * +index+ can be an Integer (positive, negative, or zero), a Symbol,
+ * +specifier+ can be an Integer (positive, negative, or zero), a Symbol,
  * or a String for named capture groups.
  *
  * Returns +nil+ if:
  * - No match has been performed or the last match failed
- * - The +index+ is out of range
- * - The group at +index+ did not participate in the match
+ * - The +specifier+ is out of range
+ * - The group at +specifier+ did not participate in the match
  *
- * This is semantically equivalent to <tt>self[index].to_i(base)</tt>
+ * This is semantically equivalent to <tt>self[specifier].to_i(base)</tt>
  * but avoids the allocation of a temporary String when possible.
  *
  *   scanner = StringScanner.new("2024-06-15")
@@ -1896,14 +1896,14 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
     long i;
     long beg, end, len;
     const char *ptr;
-    VALUE idx, vbase;
+    VALUE specifier, vbase;
     int base = 10;
 
-    rb_scan_args(argc, argv, "11", &idx, &vbase);
+    rb_scan_args(argc, argv, "11", &specifier, &vbase);
     if (!NIL_P(vbase)) base = NUM2INT(vbase);
 
     GET_SCANNER(self, p);
-    i = resolve_capture_index(p, idx);
+    i = resolve_capture_index(p, specifier);
     if (i < 0) return Qnil;
 
     beg = adjust_register_position(p, p->regs.beg[i]);

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1624,23 +1624,23 @@ name_to_backref_number(struct re_registers *regs, VALUE regexp, const char* name
 /* Resolve capture group index from Integer, Symbol, or String.
  * Returns the resolved register index, or -1 if unmatched/out of range. */
 static long
-resolve_capture_index(struct strscanner *p, VALUE idx)
+resolve_capture_index(struct strscanner *p, VALUE specifier)
 {
     const char *name;
     long i;
 
     if (! MATCHED_P(p)) return -1;
 
-    switch (TYPE(idx)) {
+    switch (TYPE(specifier)) {
         case T_SYMBOL:
-            idx = rb_sym2str(idx);
+            specifier = rb_sym2str(specifier);
             /* fall through */
         case T_STRING:
-            RSTRING_GETMEM(idx, name, i);
-            i = name_to_backref_number(&(p->regs), p->regex, name, name + i, rb_enc_get(idx));
+            RSTRING_GETMEM(specifier, name, i);
+            i = name_to_backref_number(&(p->regs), p->regex, name, name + i, rb_enc_get(specifier));
             break;
         default:
-            i = NUM2LONG(idx);
+            i = NUM2LONG(specifier);
     }
 
     if (i < 0)

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1966,6 +1966,8 @@ parse_decimal_fast(const char *ptr, long len)
             for (; j < len; j++) {
                 if (ptr[j] != '_') {
                     unsigned long d = ptr[j] - '0';
+                    /* Pre-check before multiply to avoid unsigned long wraparound on
+                     * 32-bit platforms, where 10-digit values can exceed ULONG_MAX. */
                     if (result > (limit - d) / 10) {
                         overflow = true;
                         break;

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1949,12 +1949,14 @@ parse_decimal_fast(const char *ptr, long len)
             }
             if (!overflow) {
                 if (negative) {
-                    if (result == limit)
+                    if (result == limit) {
                         return LONG2NUM(LONG_MIN);
+                    }
                     return LONG2NUM(-(long)result);
                 }
-                else
+                else {
                     return LONG2NUM((long)result);
+                }
             }
         }
     }
@@ -2012,7 +2014,7 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
     end = adjust_register_position(p, p->regs.end[i]);
     len = end - beg;
 
-    if (len <= 0) return INT2FIX(0);
+    if (len <= 0) return INT2FIX(0); /* empty capture: String#to_i("") == 0 */
 
     ptr = S_PBEG(p) + beg;
 

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1979,7 +1979,8 @@ parse_decimal_fast(const char *ptr, long len)
                         return LONG2NUM(LONG_MIN);
                     return LONG2NUM(-(long)result);
                 }
-                return LONG2NUM((long)result);
+                else
+                    return LONG2NUM((long)result);
             }
         }
     }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1877,19 +1877,19 @@ strscan_values_at(int argc, VALUE *argv, VALUE self)
 static inline VALUE
 parse_decimal_fast(const char *ptr, long len)
 {
-    long j = 0;
+    long digits_start = 0;
     bool negative = false;
     long digit_count = 0;
     bool valid = true;
 
-    if (ptr[0] == '-') { negative = true; j = 1; }
-    else if (ptr[0] == '+') { j = 1; }
+    if (ptr[0] == '-') { negative = true; digits_start = 1; }
+    else if (ptr[0] == '+') { digits_start = 1; }
 
     /* Validate: only digits and underscores (not leading/trailing/consecutive) */
     {
         long k;
         bool prev_underscore = true; /* treat start as underscore to reject leading _ */
-        for (k = j; k < len; k++) {
+        for (k = digits_start; k < len; k++) {
             if (ptr[k] >= '0' && ptr[k] <= '9') {
                 digit_count++;
                 prev_underscore = false;
@@ -1909,7 +1909,7 @@ parse_decimal_fast(const char *ptr, long len)
 
     /* Skip leading zeros to get effective digit count */
     {
-        long first_nonzero = j;
+        long first_nonzero = digits_start;
         long effective_digits;
         long k;
         while (first_nonzero < len && (ptr[first_nonzero] == '0' || ptr[first_nonzero] == '_'))

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1921,9 +1921,9 @@ parse_decimal_fast(const char *ptr, long len)
 
         if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS : INT32_DECIMAL_SAFE_DIGITS)) {
             long result = 0;
-            for (; j < len; j++) {
-                if (ptr[j] != '_')
-                    result = result * 10 + (ptr[j] - '0');
+            for (k = first_nonzero; k < len; k++) {
+                if (ptr[k] != '_')
+                    result = result * 10 + (ptr[k] - '0');
             }
             if (negative) result = -result;
             return LONG2NUM(result);
@@ -1935,9 +1935,9 @@ parse_decimal_fast(const char *ptr, long len)
                 ? (unsigned long)LONG_MAX + 1
                 : (unsigned long)LONG_MAX;
             bool overflow = false;
-            for (; j < len; j++) {
-                if (ptr[j] != '_') {
-                    unsigned long d = ptr[j] - '0';
+            for (k = first_nonzero; k < len; k++) {
+                if (ptr[k] != '_') {
+                    unsigned long d = ptr[k] - '0';
                     /* Pre-check before multiply to avoid unsigned long wraparound on
                      * 32-bit platforms, where 10-digit values can exceed ULONG_MAX. */
                     if (result > (limit - d) / 10) {

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1914,6 +1914,11 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
 
     ptr = S_PBEG(p) + beg;
 
+    /* Max decimal digits guaranteed to fit in long without overflow check.
+     * floor(log10(INT64_MAX)) = 18, floor(log10(INT32_MAX)) = 9 */
+#define INT64_DECIMAL_SAFE_DIGITS 18
+#define INT32_DECIMAL_SAFE_DIGITS 9
+
     /* Fast path for base 10 with pure digits: parse directly from
      * source bytes without temporary String allocation.
      * This covers the Date._strptime use case. */
@@ -1943,7 +1948,7 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
                     first_nonzero++;
                 effective_digits = len - first_nonzero;
 
-                if (effective_digits <= (sizeof(long) >= 8 ? 18 : 9)) {
+                if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS : INT32_DECIMAL_SAFE_DIGITS)) {
                     long result = 0;
                     for (; j < len; j++) {
                         result = result * 10 + (ptr[j] - '0');
@@ -1951,8 +1956,8 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
                     if (negative) result = -result;
                     return LONG2NUM(result);
                 }
-                /* 19 digits on 64-bit (or 10 on 32-bit): may fit in long */
-                if (effective_digits <= (sizeof(long) >= 8 ? 19 : 10)) {
+                /* One more digit than safe: may still fit in long with overflow check */
+                if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS + 1 : INT32_DECIMAL_SAFE_DIGITS + 1)) {
                     unsigned long result = 0;
                     unsigned long limit = negative
                         ? (unsigned long)LONG_MAX + 1

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1966,11 +1966,11 @@ parse_decimal_fast(const char *ptr, long len)
             for (; j < len; j++) {
                 if (ptr[j] != '_') {
                     unsigned long d = ptr[j] - '0';
-                    result = result * 10 + d;
-                    if (result > limit) {
+                    if (result > (limit - d) / 10) {
                         overflow = true;
                         break;
                     }
+                    result = result * 10 + d;
                 }
             }
             if (!overflow) {

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1996,8 +1996,11 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
                     }
                 }
                 if (!overflow) {
-                    if (negative)
+                    if (negative) {
+                        if (result == (unsigned long)LONG_MAX + 1)
+                            return LONG2NUM(LONG_MIN);
                         return LONG2NUM(-(long)result);
+                    }
                     return LONG2NUM((long)result);
                 }
             }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1865,34 +1865,6 @@ strscan_values_at(int argc, VALUE *argv, VALUE self)
     return new_ary;
 }
 
-/*
- * call-seq:
- *   integer_at(specifier, base = 10) -> integer or nil
- *
- * Returns the captured substring at the given +specifier+ as an Integer,
- * following the behavior of <tt>String#to_i(base)</tt>.
- *
- * +specifier+ can be an Integer (positive, negative, or zero), a Symbol,
- * or a String for named capture groups.
- *
- * Returns +nil+ if:
- * - No match has been performed or the last match failed
- * - The +specifier+ is an Integer and is out of range
- * - The group at +specifier+ did not participate in the match
- *
- * Raises IndexError if +specifier+ is a Symbol or String that does not
- * correspond to a named capture group, consistent with
- * <tt>StringScanner#[]</tt>.
- *
- * This is semantically equivalent to <tt>self[specifier].to_i(base)</tt>
- * but avoids the allocation of a temporary String when possible.
- *
- *   scanner = StringScanner.new("2024-06-15")
- *   scanner.scan(/(\d{4})-(\d{2})-(\d{2})/)
- *   scanner.integer_at(1)       # => 2024
- *   scanner.integer_at(1, 16)   # => 8228
- *
- */
 /* Max decimal digits guaranteed to fit in long without overflow check.
  * floor(log10(INT64_MAX)) = 18, floor(log10(INT32_MAX)) = 9 */
 #define INT64_DECIMAL_SAFE_DIGITS 18
@@ -1990,6 +1962,34 @@ parse_decimal_fast(const char *ptr, long len)
     return Qundef;
 }
 
+/*
+ * call-seq:
+ *   integer_at(specifier, base = 10) -> integer or nil
+ *
+ * Returns the captured substring at the given +specifier+ as an Integer,
+ * following the behavior of <tt>String#to_i(base)</tt>.
+ *
+ * +specifier+ can be an Integer (positive, negative, or zero), a Symbol,
+ * or a String for named capture groups.
+ *
+ * Returns +nil+ if:
+ * - No match has been performed or the last match failed
+ * - The +specifier+ is an Integer and is out of range
+ * - The group at +specifier+ did not participate in the match
+ *
+ * Raises IndexError if +specifier+ is a Symbol or String that does not
+ * correspond to a named capture group, consistent with
+ * <tt>StringScanner#[]</tt>.
+ *
+ * This is semantically equivalent to <tt>self[specifier].to_i(base)</tt>
+ * but avoids the allocation of a temporary String when possible.
+ *
+ *   scanner = StringScanner.new("2024-06-15")
+ *   scanner.scan(/(\d{4})-(\d{2})-(\d{2})/)
+ *   scanner.integer_at(1)       # => 2024
+ *   scanner.integer_at(1, 16)   # => 8228
+ *
+ */
 static VALUE
 strscan_integer_at(int argc, VALUE *argv, VALUE self)
 {

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1914,7 +1914,42 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
 
     ptr = S_PBEG(p) + beg;
 
-    /* Follow String#to_i(base) semantics via rb_str_to_inum.
+    /* Fast path for base 10 with pure digits: parse directly from
+     * source bytes without temporary String allocation.
+     * This covers the Date._strptime use case. */
+    if (base == 10) {
+        long j = 0;
+        int negative = 0;
+        long digit_count;
+
+        if (ptr[0] == '-') { negative = 1; j = 1; }
+        else if (ptr[0] == '+') { j = 1; }
+
+        digit_count = len - j;
+        if (digit_count > 0) {
+            long k;
+            int all_digits = 1;
+            for (k = j; k < len; k++) {
+                if (ptr[k] < '0' || ptr[k] > '9') {
+                    all_digits = 0;
+                    break;
+                }
+            }
+            if (all_digits) {
+                if (digit_count <= (sizeof(long) >= 8 ? 18 : 9)) {
+                    long result = 0;
+                    for (; j < len; j++) {
+                        result = result * 10 + (ptr[j] - '0');
+                    }
+                    if (negative) result = -result;
+                    return LONG2NUM(result);
+                }
+                /* Bignum: fall through to rb_str_to_inum */
+            }
+        }
+    }
+
+    /* General path: follow String#to_i(base) semantics via rb_str_to_inum.
      * badcheck=0 returns 0 for non-numeric input instead of raising. */
     return rb_str_to_inum(rb_str_new(ptr, len), base, 0);
 }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1877,8 +1877,12 @@ strscan_values_at(int argc, VALUE *argv, VALUE self)
  *
  * Returns +nil+ if:
  * - No match has been performed or the last match failed
- * - The +specifier+ is out of range
+ * - The +specifier+ is an Integer and is out of range
  * - The group at +specifier+ did not participate in the match
+ *
+ * Raises IndexError if +specifier+ is a Symbol or String that does not
+ * correspond to a named capture group, consistent with
+ * <tt>StringScanner#[]</tt>.
  *
  * This is semantically equivalent to <tt>self[specifier].to_i(base)</tt>
  * but avoids the allocation of a temporary String when possible.

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1936,13 +1936,41 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
                 }
             }
             if (all_digits) {
-                if (digit_count <= (sizeof(long) >= 8 ? 18 : 9)) {
+                /* Skip leading zeros to get effective digit count */
+                long first_nonzero = j;
+                long effective_digits;
+                while (first_nonzero < len && ptr[first_nonzero] == '0')
+                    first_nonzero++;
+                effective_digits = len - first_nonzero;
+
+                if (effective_digits <= (sizeof(long) >= 8 ? 18 : 9)) {
                     long result = 0;
                     for (; j < len; j++) {
                         result = result * 10 + (ptr[j] - '0');
                     }
                     if (negative) result = -result;
                     return LONG2NUM(result);
+                }
+                /* 19 digits on 64-bit (or 10 on 32-bit): may fit in long */
+                if (effective_digits <= (sizeof(long) >= 8 ? 19 : 10)) {
+                    unsigned long result = 0;
+                    unsigned long limit = negative
+                        ? (unsigned long)LONG_MAX + 1
+                        : (unsigned long)LONG_MAX;
+                    bool overflow = false;
+                    for (; j < len; j++) {
+                        unsigned long d = ptr[j] - '0';
+                        if (result > (limit - d) / 10) {
+                            overflow = true;
+                            break;
+                        }
+                        result = result * 10 + d;
+                    }
+                    if (!overflow) {
+                        if (negative)
+                            return LONG2NUM(-(long)result);
+                        return LONG2NUM((long)result);
+                    }
                 }
                 /* Bignum: fall through to rb_str_to_inum */
             }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1949,7 +1949,7 @@ parse_decimal_fast(const char *ptr, long len)
             }
             if (!overflow) {
                 if (negative) {
-                    if (result == (unsigned long)LONG_MAX + 1)
+                    if (result == limit)
                         return LONG2NUM(LONG_MIN);
                     return LONG2NUM(-(long)result);
                 }

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1957,7 +1957,7 @@ parse_decimal_fast(const char *ptr, long len)
             return LONG2NUM(result);
         }
         /* One more digit than safe: may still fit in long with overflow check */
-        if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS + 1 : INT32_DECIMAL_SAFE_DIGITS + 1)) {
+        else if (effective_digits == (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS + 1 : INT32_DECIMAL_SAFE_DIGITS + 1)) {
             unsigned long result = 0;
             unsigned long limit = negative
                 ? (unsigned long)LONG_MAX + 1

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1919,51 +1919,70 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
 #define INT64_DECIMAL_SAFE_DIGITS 18
 #define INT32_DECIMAL_SAFE_DIGITS 9
 
-    /* Fast path for base 10 with pure digits: parse directly from
-     * source bytes without temporary String allocation.
+    /* Fast path for base 10 with digits and optional underscores:
+     * parse directly from source bytes without temporary String allocation.
      * This covers the Date._strptime use case. */
     if (base == 10) {
         long j = 0;
         bool negative = false;
-        long digit_count;
+        long digit_count = 0;
+        bool valid = true;
 
         if (ptr[0] == '-') { negative = true; j = 1; }
         else if (ptr[0] == '+') { j = 1; }
 
-        digit_count = len - j;
-        if (digit_count > 0) {
+        /* Validate: only digits and underscores (not leading/trailing/consecutive) */
+        {
             long k;
-            bool all_digits = true;
+            bool prev_underscore = true; /* treat start as underscore to reject leading _ */
             for (k = j; k < len; k++) {
-                if (ptr[k] < '0' || ptr[k] > '9') {
-                    all_digits = false;
+                if (ptr[k] >= '0' && ptr[k] <= '9') {
+                    digit_count++;
+                    prev_underscore = false;
+                }
+                else if (ptr[k] == '_' && !prev_underscore) {
+                    prev_underscore = true;
+                }
+                else {
+                    valid = false;
                     break;
                 }
             }
-            if (all_digits) {
-                /* Skip leading zeros to get effective digit count */
-                long first_nonzero = j;
-                long effective_digits;
-                while (first_nonzero < len && ptr[first_nonzero] == '0')
-                    first_nonzero++;
-                effective_digits = len - first_nonzero;
+            if (prev_underscore && digit_count > 0) valid = false; /* trailing _ */
+        }
 
-                if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS : INT32_DECIMAL_SAFE_DIGITS)) {
-                    long result = 0;
-                    for (; j < len; j++) {
-                        result = result * 10 + (ptr[j] - '0');
-                    }
-                    if (negative) result = -result;
-                    return LONG2NUM(result);
+        if (valid && digit_count > 0) {
+            /* Skip leading zeros to get effective digit count */
+            long first_nonzero = j;
+            long effective_digits;
+            while (first_nonzero < len && (ptr[first_nonzero] == '0' || ptr[first_nonzero] == '_'))
+                first_nonzero++;
+            effective_digits = 0;
+            {
+                long k;
+                for (k = first_nonzero; k < len; k++) {
+                    if (ptr[k] != '_') effective_digits++;
                 }
-                /* One more digit than safe: may still fit in long with overflow check */
-                if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS + 1 : INT32_DECIMAL_SAFE_DIGITS + 1)) {
-                    unsigned long result = 0;
-                    unsigned long limit = negative
-                        ? (unsigned long)LONG_MAX + 1
-                        : (unsigned long)LONG_MAX;
-                    bool overflow = false;
-                    for (; j < len; j++) {
+            }
+
+            if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS : INT32_DECIMAL_SAFE_DIGITS)) {
+                long result = 0;
+                for (; j < len; j++) {
+                    if (ptr[j] != '_')
+                        result = result * 10 + (ptr[j] - '0');
+                }
+                if (negative) result = -result;
+                return LONG2NUM(result);
+            }
+            /* One more digit than safe: may still fit in long with overflow check */
+            if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS + 1 : INT32_DECIMAL_SAFE_DIGITS + 1)) {
+                unsigned long result = 0;
+                unsigned long limit = negative
+                    ? (unsigned long)LONG_MAX + 1
+                    : (unsigned long)LONG_MAX;
+                bool overflow = false;
+                for (; j < len; j++) {
+                    if (ptr[j] != '_') {
                         unsigned long d = ptr[j] - '0';
                         if (result > (limit - d) / 10) {
                             overflow = true;
@@ -1971,14 +1990,14 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
                         }
                         result = result * 10 + d;
                     }
-                    if (!overflow) {
-                        if (negative)
-                            return LONG2NUM(-(long)result);
-                        return LONG2NUM((long)result);
-                    }
                 }
-                /* Bignum: fall through to rb_str_to_inum */
+                if (!overflow) {
+                    if (negative)
+                        return LONG2NUM(-(long)result);
+                    return LONG2NUM((long)result);
+                }
             }
+            /* Bignum: fall through to rb_str_to_inum */
         }
     }
 

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1893,6 +1893,100 @@ strscan_values_at(int argc, VALUE *argv, VALUE self)
  *   scanner.integer_at(1, 16)   # => 8228
  *
  */
+/* Max decimal digits guaranteed to fit in long without overflow check.
+ * floor(log10(INT64_MAX)) = 18, floor(log10(INT32_MAX)) = 9 */
+#define INT64_DECIMAL_SAFE_DIGITS 18
+#define INT32_DECIMAL_SAFE_DIGITS 9
+
+/* Fast path for base-10 integer parsing without temporary String allocation.
+ * Accepts digits and optional underscores (Ruby String#to_i semantics).
+ * Returns a Fixnum/Integer VALUE on success, or Qundef to signal fall-through
+ * to the general path (non-decimal, bignum, or non-numeric input). */
+static inline VALUE
+parse_decimal_fast(const char *ptr, long len)
+{
+    long j = 0;
+    bool negative = false;
+    long digit_count = 0;
+    bool valid = true;
+
+    if (ptr[0] == '-') { negative = true; j = 1; }
+    else if (ptr[0] == '+') { j = 1; }
+
+    /* Validate: only digits and underscores (not leading/trailing/consecutive) */
+    {
+        long k;
+        bool prev_underscore = true; /* treat start as underscore to reject leading _ */
+        for (k = j; k < len; k++) {
+            if (ptr[k] >= '0' && ptr[k] <= '9') {
+                digit_count++;
+                prev_underscore = false;
+            }
+            else if (ptr[k] == '_' && !prev_underscore) {
+                prev_underscore = true;
+            }
+            else {
+                valid = false;
+                break;
+            }
+        }
+        if (prev_underscore && digit_count > 0) valid = false; /* trailing _ */
+    }
+
+    if (!valid || digit_count == 0) return Qundef;
+
+    /* Skip leading zeros to get effective digit count */
+    {
+        long first_nonzero = j;
+        long effective_digits;
+        long k;
+        while (first_nonzero < len && (ptr[first_nonzero] == '0' || ptr[first_nonzero] == '_'))
+            first_nonzero++;
+        effective_digits = 0;
+        for (k = first_nonzero; k < len; k++) {
+            if (ptr[k] != '_') effective_digits++;
+        }
+
+        if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS : INT32_DECIMAL_SAFE_DIGITS)) {
+            long result = 0;
+            for (; j < len; j++) {
+                if (ptr[j] != '_')
+                    result = result * 10 + (ptr[j] - '0');
+            }
+            if (negative) result = -result;
+            return LONG2NUM(result);
+        }
+        /* One more digit than safe: may still fit in long with overflow check */
+        if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS + 1 : INT32_DECIMAL_SAFE_DIGITS + 1)) {
+            unsigned long result = 0;
+            unsigned long limit = negative
+                ? (unsigned long)LONG_MAX + 1
+                : (unsigned long)LONG_MAX;
+            bool overflow = false;
+            for (; j < len; j++) {
+                if (ptr[j] != '_') {
+                    unsigned long d = ptr[j] - '0';
+                    if (result > (limit - d) / 10) {
+                        overflow = true;
+                        break;
+                    }
+                    result = result * 10 + d;
+                }
+            }
+            if (!overflow) {
+                if (negative) {
+                    if (result == (unsigned long)LONG_MAX + 1)
+                        return LONG2NUM(LONG_MIN);
+                    return LONG2NUM(-(long)result);
+                }
+                return LONG2NUM((long)result);
+            }
+        }
+    }
+    /* Bignum: signal fall-through to rb_str_to_inum */
+    return Qundef;
+}
+
 static VALUE
 strscan_integer_at(int argc, VALUE *argv, VALUE self)
 {
@@ -1918,94 +2012,11 @@ strscan_integer_at(int argc, VALUE *argv, VALUE self)
 
     ptr = S_PBEG(p) + beg;
 
-    /* Max decimal digits guaranteed to fit in long without overflow check.
-     * floor(log10(INT64_MAX)) = 18, floor(log10(INT32_MAX)) = 9 */
-#define INT64_DECIMAL_SAFE_DIGITS 18
-#define INT32_DECIMAL_SAFE_DIGITS 9
-
-    /* Fast path for base 10 with digits and optional underscores:
-     * parse directly from source bytes without temporary String allocation.
-     * This covers the Date._strptime use case. */
+    /* Fast path for base 10: parse directly from source bytes without
+     * temporary String allocation. This covers the Date._strptime use case. */
     if (base == 10) {
-        long j = 0;
-        bool negative = false;
-        long digit_count = 0;
-        bool valid = true;
-
-        if (ptr[0] == '-') { negative = true; j = 1; }
-        else if (ptr[0] == '+') { j = 1; }
-
-        /* Validate: only digits and underscores (not leading/trailing/consecutive) */
-        {
-            long k;
-            bool prev_underscore = true; /* treat start as underscore to reject leading _ */
-            for (k = j; k < len; k++) {
-                if (ptr[k] >= '0' && ptr[k] <= '9') {
-                    digit_count++;
-                    prev_underscore = false;
-                }
-                else if (ptr[k] == '_' && !prev_underscore) {
-                    prev_underscore = true;
-                }
-                else {
-                    valid = false;
-                    break;
-                }
-            }
-            if (prev_underscore && digit_count > 0) valid = false; /* trailing _ */
-        }
-
-        if (valid && digit_count > 0) {
-            /* Skip leading zeros to get effective digit count */
-            long first_nonzero = j;
-            long effective_digits;
-            while (first_nonzero < len && (ptr[first_nonzero] == '0' || ptr[first_nonzero] == '_'))
-                first_nonzero++;
-            effective_digits = 0;
-            {
-                long k;
-                for (k = first_nonzero; k < len; k++) {
-                    if (ptr[k] != '_') effective_digits++;
-                }
-            }
-
-            if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS : INT32_DECIMAL_SAFE_DIGITS)) {
-                long result = 0;
-                for (; j < len; j++) {
-                    if (ptr[j] != '_')
-                        result = result * 10 + (ptr[j] - '0');
-                }
-                if (negative) result = -result;
-                return LONG2NUM(result);
-            }
-            /* One more digit than safe: may still fit in long with overflow check */
-            if (effective_digits <= (sizeof(long) >= 8 ? INT64_DECIMAL_SAFE_DIGITS + 1 : INT32_DECIMAL_SAFE_DIGITS + 1)) {
-                unsigned long result = 0;
-                unsigned long limit = negative
-                    ? (unsigned long)LONG_MAX + 1
-                    : (unsigned long)LONG_MAX;
-                bool overflow = false;
-                for (; j < len; j++) {
-                    if (ptr[j] != '_') {
-                        unsigned long d = ptr[j] - '0';
-                        if (result > (limit - d) / 10) {
-                            overflow = true;
-                            break;
-                        }
-                        result = result * 10 + d;
-                    }
-                }
-                if (!overflow) {
-                    if (negative) {
-                        if (result == (unsigned long)LONG_MAX + 1)
-                            return LONG2NUM(LONG_MIN);
-                        return LONG2NUM(-(long)result);
-                    }
-                    return LONG2NUM((long)result);
-                }
-            }
-            /* Bignum: fall through to rb_str_to_inum */
-        }
+        VALUE result = parse_decimal_fast(ptr, len);
+        if (result != Qundef) return result;
     }
 
     /* General path: follow String#to_i(base) semantics via rb_str_to_inum.

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -1966,11 +1966,11 @@ parse_decimal_fast(const char *ptr, long len)
             for (; j < len; j++) {
                 if (ptr[j] != '_') {
                     unsigned long d = ptr[j] - '0';
-                    if (result > (limit - d) / 10) {
+                    result = result * 10 + d;
+                    if (result > limit) {
                         overflow = true;
                         break;
                     }
-                    result = result * 10 + d;
                 }
             }
             if (!overflow) {

--- a/lib/strscan/strscan.rb
+++ b/lib/strscan/strscan.rb
@@ -12,6 +12,16 @@ class StringScanner
   #
   # The scanned string must be encoded with an ASCII compatible encoding, otherwise
   # Encoding::CompatibilityError will be raised.
+  unless method_defined?(:integer_at)
+    # Fallback implementation for platforms without C extension (e.g. JRuby).
+    # Equivalent to self[index].to_i(base).
+    def integer_at(index, base = 10)
+      str = self[index]
+      return nil if str.nil?
+      str.to_i(base)
+    end
+  end
+
   def scan_integer(base: 10)
     case base
     when 10

--- a/lib/strscan/strscan.rb
+++ b/lib/strscan/strscan.rb
@@ -25,9 +25,9 @@ class StringScanner
 
   unless method_defined?(:integer_at)
     # Fallback implementation for platforms without C extension (e.g. JRuby).
-    # Equivalent to self[index].to_i(base).
-    def integer_at(index, base = 10)
-      str = self[index]
+    # Equivalent to self[specifier].to_i(base).
+    def integer_at(specifier, base = 10)
+      str = self[specifier]
       return nil if str.nil?
       str.to_i(base)
     end

--- a/lib/strscan/strscan.rb
+++ b/lib/strscan/strscan.rb
@@ -12,16 +12,6 @@ class StringScanner
   #
   # The scanned string must be encoded with an ASCII compatible encoding, otherwise
   # Encoding::CompatibilityError will be raised.
-  unless method_defined?(:integer_at)
-    # Fallback implementation for platforms without C extension (e.g. JRuby).
-    # Equivalent to self[index].to_i(base).
-    def integer_at(index, base = 10)
-      str = self[index]
-      return nil if str.nil?
-      str.to_i(base)
-    end
-  end
-
   def scan_integer(base: 10)
     case base
     when 10
@@ -30,6 +20,16 @@ class StringScanner
       scan_base16_integer
     else
       raise ArgumentError, "Unsupported integer base: #{base.inspect}, expected 10 or 16"
+    end
+  end
+
+  unless method_defined?(:integer_at)
+    # Fallback implementation for platforms without C extension (e.g. JRuby).
+    # Equivalent to self[index].to_i(base).
+    def integer_at(index, base = 10)
+      str = self[index]
+      return nil if str.nil?
+      str.to_i(base)
     end
   end
 end

--- a/lib/strscan/strscan.rb
+++ b/lib/strscan/strscan.rb
@@ -27,9 +27,7 @@ class StringScanner
     # Fallback implementation for platforms without C extension (e.g. JRuby).
     # Equivalent to self[specifier].to_i(base).
     def integer_at(specifier, base = 10)
-      str = self[specifier]
-      return nil if str.nil?
-      str.to_i(base)
+      self[specifier]&.to_i(base)
     end
   end
 end

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1018,10 +1018,10 @@ module StringScannerTests
   end
 
   def test_integer_at_large_number
-    huge = '9' * 100
-    s = create_string_scanner(huge)
+    large = '9' * 100
+    s = create_string_scanner(large)
     s.scan(/(\d+)/)
-    assert_equal(huge.to_i, s.integer_at(1))
+    assert_equal(large.to_i, s.integer_at(1))
   end
 
   def test_integer_at_fixnum_bignum_boundary

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1025,22 +1025,22 @@ module StringScannerTests
   end
 
   def test_integer_at_fixnum_bignum_boundary
-    # 18 digits max ("9" * 18): largest value without overflow check
+    # 18 digits max on 64-bit ("9" * 18): largest value without overflow check
     s = create_string_scanner("9" * 18)
     s.scan(/(\d+)/)
     assert_equal(("9" * 18).to_i, s.integer_at(1))
 
-    # 19 digits min ("1" * 19): smallest value with overflow check
+    # 19 digits min on 64-bit ("1" * 19): smallest value with overflow check
     s = create_string_scanner("1" * 19)
     s.scan(/(\d+)/)
     assert_equal(("1" * 19).to_i, s.integer_at(1))
 
-    # negative 18 digits max
+    # negative 18 digits max on 64-bit
     s = create_string_scanner("-" + "9" * 18)
     s.scan(/([+\-]?\d+)/)
     assert_equal(-("9" * 18).to_i, s.integer_at(1))
 
-    # negative 19 digits min
+    # negative 19 digits min on 64-bit
     s = create_string_scanner("-" + "1" * 19)
     s.scan(/([+\-]?\d+)/)
     assert_equal(-("1" * 19).to_i, s.integer_at(1))

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -968,7 +968,7 @@ module StringScannerTests
     assert_equal({"number" => "1"}, scan.named_captures)
   end
 
-  def test_integer_at
+  def test_integer_at_date_parts
     s = create_string_scanner("2024-06-15")
     s.scan(/(\d{4})-(\d{2})-(\d{2})/)
     assert_equal(2024, s.integer_at(1))

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1160,6 +1160,9 @@ module StringScannerTests
     assert_equal(2024, s.integer_at(1))       # default base 10
     assert_equal(1044, s.integer_at(1, 8))    # base 8
     assert_equal(8228, s.integer_at(1, 16))   # base 16
+
+    # explicit nil raises TypeError (consistent with String#to_i and MatchData#integer_at)
+    assert_raise(TypeError) { s.integer_at(1, nil) }
   end
 
   def test_integer_at_base_zero

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -968,6 +968,186 @@ module StringScannerTests
     assert_equal({"number" => "1"}, scan.named_captures)
   end
 
+  def test_integer_at
+    s = create_string_scanner("2024-06-15")
+    s.scan(/(\d{4})-(\d{2})-(\d{2})/)
+    assert_equal(2024, s.integer_at(1))
+    assert_equal(6, s.integer_at(2))
+    assert_equal(15, s.integer_at(3))
+  end
+
+  def test_integer_at_index_zero
+    s = create_string_scanner("42 abc")
+    s.scan(/(\d+)/)
+    assert_equal(42, s.integer_at(0))
+  end
+
+  def test_integer_at_negative_index
+    s = create_string_scanner("2024-06-15")
+    s.scan(/(\d{4})-(\d{2})-(\d{2})/)
+    assert_equal(15, s.integer_at(-1))
+    assert_equal(6, s.integer_at(-2))
+    assert_equal(2024, s.integer_at(-3))
+  end
+
+  def test_integer_at_no_match
+    s = create_string_scanner("abc")
+    s.scan(/\d+/)
+    assert_nil(s.integer_at(0))
+  end
+
+  def test_integer_at_before_match
+    s = create_string_scanner("abc")
+    assert_nil(s.integer_at(0))
+  end
+
+  def test_integer_at_index_out_of_range
+    s = create_string_scanner("42")
+    s.scan(/(\d+)/)
+    assert_nil(s.integer_at(2))
+    assert_nil(s.integer_at(100))
+    assert_nil(s.integer_at(-3))
+  end
+
+  def test_integer_at_optional_group_not_matched
+    s = create_string_scanner("2024-06")
+    s.scan(/(\d{4})-(\d{2})(-(\d{2}))?/)
+    assert_equal(2024, s.integer_at(1))
+    assert_equal(6, s.integer_at(2))
+    assert_nil(s.integer_at(4))
+  end
+
+  def test_integer_at_large_number
+    huge = '9' * 100
+    s = create_string_scanner(huge)
+    s.scan(/(\d+)/)
+    assert_equal(huge.to_i, s.integer_at(1))
+  end
+
+  def test_integer_at_fixnum_bignum_boundary
+    # 18 digits: fits in long on 64-bit
+    s = create_string_scanner("999999999999999999")
+    s.scan(/(\d+)/)
+    assert_equal(999999999999999999, s.integer_at(1))
+
+    # 19 digits: exceeds long on 64-bit, becomes bignum
+    s = create_string_scanner("9999999999999999999")
+    s.scan(/(\d+)/)
+    assert_equal(9999999999999999999, s.integer_at(1))
+
+    # negative 18 digits
+    s = create_string_scanner("-999999999999999999")
+    s.scan(/([+\-]?\d+)/)
+    assert_equal(-999999999999999999, s.integer_at(1))
+
+    # negative 19 digits
+    s = create_string_scanner("-9999999999999999999")
+    s.scan(/([+\-]?\d+)/)
+    assert_equal(-9999999999999999999, s.integer_at(1))
+  end
+
+  def test_integer_at_non_digit
+    # follows String#to_i: stops at non-digit, returns parsed portion
+    s = create_string_scanner("1.5")
+    s.scan(/([\d.]+)/)
+    assert_equal(1, s.integer_at(1))
+  end
+
+  def test_integer_at_non_digit_alpha
+    # follows String#to_i: no leading digits, returns 0
+    s = create_string_scanner("foo bar")
+    s.scan(/(\w+)/)
+    assert_equal(0, s.integer_at(1))
+  end
+
+  def test_integer_at_empty_capture
+    # follows String#to_i: empty string returns 0
+    s = create_string_scanner("abc")
+    s.scan(/()abc/)
+    assert_equal(0, s.integer_at(1))
+  end
+
+  def test_integer_at_sign_only
+    # follows String#to_i: sign only returns 0
+    s = create_string_scanner("+")
+    s.scan(/([+\-])/)
+    assert_equal(0, s.integer_at(1))
+
+    s = create_string_scanner("-")
+    s.scan(/([+\-])/)
+    assert_equal(0, s.integer_at(1))
+  end
+
+  def test_integer_at_signed_number
+    s = create_string_scanner("-42")
+    s.scan(/([+\-]?\d+)/)
+    assert_equal(-42, s.integer_at(1))
+
+    s = create_string_scanner("+42")
+    s.scan(/([+\-]?\d+)/)
+    assert_equal(42, s.integer_at(1))
+  end
+
+  def test_integer_at_leading_zeros
+    # "010" is 8 in octal (Integer("010")), but 10 in base 10
+    s = create_string_scanner("010")
+    s.scan(/(\d+)/)
+    assert_equal(10, s.integer_at(1))
+  end
+
+  def test_integer_at_full_match_with_non_digits
+    # follows String#to_i: "2024-06-15".to_i => 2024
+    s = create_string_scanner("2024-06-15")
+    s.scan(/(\d{4})-(\d{2})-(\d{2})/)
+    assert_equal(2024, s.integer_at(0))
+  end
+
+  def test_integer_at_named_capture_symbol
+    s = create_string_scanner("2024-06-15")
+    s.scan(/(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/)
+    assert_equal(2024, s.integer_at(:year))
+    assert_equal(6, s.integer_at(:month))
+    assert_equal(15, s.integer_at(:day))
+  end
+
+  def test_integer_at_named_capture_string
+    s = create_string_scanner("2024-06-15")
+    s.scan(/(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/)
+    assert_equal(2024, s.integer_at("year"))
+    assert_equal(6, s.integer_at("month"))
+    assert_equal(15, s.integer_at("day"))
+  end
+
+  def test_integer_at_named_capture_undefined
+    s = create_string_scanner("2024-06-15")
+    s.scan(/(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/)
+    assert_raise(IndexError) { s.integer_at(:unknown) }
+    assert_raise(IndexError) { s.integer_at("unknown") }
+  end
+
+  def test_integer_at_base
+    s = create_string_scanner("2024")
+    s.scan(/(\d+)/)
+    assert_equal(2024, s.integer_at(1))       # default base 10
+    assert_equal(1044, s.integer_at(1, 8))    # base 8
+    assert_equal(8228, s.integer_at(1, 16))   # base 16
+  end
+
+  def test_integer_at_base_zero
+    # base 0 respects prefixes like 0x
+    s = create_string_scanner("0xF")
+    s.scan(/(...)/)
+    assert_equal(0, s.integer_at(1))       # base 10: "0xF".to_i => 0
+    assert_equal(15, s.integer_at(1, 0))   # base 0: "0xF".to_i(0) => 15
+  end
+
+  def test_integer_at_underscore
+    # follows String#to_i: underscores are accepted
+    s = create_string_scanner("1_0_0")
+    s.scan(/(\d+(?:_\d+)*)/)
+    assert_equal(100, s.integer_at(1))
+  end
+
   def test_scan_integer
     s = create_string_scanner('abc')
     assert_equal(3, s.match?(/(?<a>abc)/)) # set named_captures

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1046,10 +1046,10 @@ module StringScannerTests
     s.scan(/([+\-]?\d+)/)
     assert_equal(-("9" * 18).to_i, s.integer_at(1))
 
-    # negative 19 digits min on 64-bit
-    s = create_string_scanner("-" + "1" * 19)
+    # negative 19 digits min on 64-bit ("-" + "1" + "0" * 18): smallest absolute value with overflow check
+    s = create_string_scanner("-" + "1" + "0" * 18)
     s.scan(/([+\-]?\d+)/)
-    assert_equal(-("1" * 19).to_i, s.integer_at(1))
+    assert_equal(-("1" + "0" * 18).to_i, s.integer_at(1))
 
     # LONG_MAX (19 digits, fits in long)
     long_max = 2 ** (0.size * 8 - 1) - 1

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1025,25 +1025,25 @@ module StringScannerTests
   end
 
   def test_integer_at_fixnum_bignum_boundary
-    # 18 digits: fits in long on 64-bit
-    s = create_string_scanner("999999999999999999")
+    # 18 digits max ("9" * 18): largest value without overflow check
+    s = create_string_scanner("9" * 18)
     s.scan(/(\d+)/)
-    assert_equal(999999999999999999, s.integer_at(1))
+    assert_equal(("9" * 18).to_i, s.integer_at(1))
 
-    # 19 digits: exceeds long on 64-bit, becomes bignum
-    s = create_string_scanner("9999999999999999999")
+    # 19 digits min ("1" * 19): smallest value with overflow check
+    s = create_string_scanner("1" * 19)
     s.scan(/(\d+)/)
-    assert_equal(9999999999999999999, s.integer_at(1))
+    assert_equal(("1" * 19).to_i, s.integer_at(1))
 
-    # negative 18 digits
-    s = create_string_scanner("-999999999999999999")
+    # negative 18 digits max
+    s = create_string_scanner("-" + "9" * 18)
     s.scan(/([+\-]?\d+)/)
-    assert_equal(-999999999999999999, s.integer_at(1))
+    assert_equal(-("9" * 18).to_i, s.integer_at(1))
 
-    # negative 19 digits
-    s = create_string_scanner("-9999999999999999999")
+    # negative 19 digits min
+    s = create_string_scanner("-" + "1" * 19)
     s.scan(/([+\-]?\d+)/)
-    assert_equal(-9999999999999999999, s.integer_at(1))
+    assert_equal(-("1" * 19).to_i, s.integer_at(1))
 
     # LONG_MAX (19 digits, fits in long)
     long_max = 2 ** (0.size * 8 - 1) - 1
@@ -1061,6 +1061,11 @@ module StringScannerTests
     s = create_string_scanner((long_max + 1).to_s)
     s.scan(/(\d+)/)
     assert_equal(long_max + 1, s.integer_at(1))
+
+    # LONG_MIN - 1 (negative bignum)
+    s = create_string_scanner((long_min - 1).to_s)
+    s.scan(/([+\-]?\d+)/)
+    assert_equal(long_min - 1, s.integer_at(1))
 
     # leading zeros with many digits
     s = create_string_scanner("00000000000000000001")

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1030,7 +1030,7 @@ module StringScannerTests
     assert_equal(large.to_i, s.integer_at(1))
   end
 
-  def test_integer_at_fixnum_bignum_boundary
+  def test_integer_at_digit_count_boundary
     # 18 digits max on 64-bit ("9" * 18): largest value without overflow check
     s = create_string_scanner("9" * 18)
     s.scan(/(\d+)/)
@@ -1050,15 +1050,18 @@ module StringScannerTests
     s = create_string_scanner("-" + "1" + "0" * 18)
     s.scan(/([+\-]?\d+)/)
     assert_equal(-("1" + "0" * 18).to_i, s.integer_at(1))
+  end
+
+  def test_integer_at_long_boundary
+    long_max = 2 ** (0.size * 8 - 1) - 1
+    long_min = -(2 ** (0.size * 8 - 1))
 
     # LONG_MAX (19 digits, fits in long)
-    long_max = 2 ** (0.size * 8 - 1) - 1
     s = create_string_scanner(long_max.to_s)
     s.scan(/(\d+)/)
     assert_equal(long_max, s.integer_at(1))
 
     # LONG_MIN (19 digits + sign, fits in long)
-    long_min = -(2 ** (0.size * 8 - 1))
     s = create_string_scanner(long_min.to_s)
     s.scan(/([+\-]?\d+)/)
     assert_equal(long_min, s.integer_at(1))
@@ -1072,11 +1075,6 @@ module StringScannerTests
     s = create_string_scanner((long_min - 1).to_s)
     s.scan(/([+\-]?\d+)/)
     assert_equal(long_min - 1, s.integer_at(1))
-
-    # leading zeros with many digits
-    s = create_string_scanner("0" * 19 + "1")
-    s.scan(/(\d+)/)
-    assert_equal(1, s.integer_at(1))
   end
 
   def test_integer_at_non_digit
@@ -1126,6 +1124,11 @@ module StringScannerTests
     s = create_string_scanner("010")
     s.scan(/(\d+)/)
     assert_equal(10, s.integer_at(1))
+
+    # leading zeros with many digits: effective digit count is 1, goes through safe path
+    s = create_string_scanner("0" * 19 + "1")
+    s.scan(/(\d+)/)
+    assert_equal(1, s.integer_at(1))
   end
 
   def test_integer_at_named_capture_symbol

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -980,6 +980,12 @@ module StringScannerTests
     s = create_string_scanner("42 abc")
     s.scan(/\d+/)
     assert_equal(42, s.integer_at(0))
+
+    # when current position is not at the beginning
+    s = create_string_scanner("a 10")
+    s.scan(/a /)
+    s.scan(/\d+/)
+    assert_equal(10, s.integer_at(0))
   end
 
   def test_integer_at_negative_index

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -968,7 +968,7 @@ module StringScannerTests
     assert_equal({"number" => "1"}, scan.named_captures)
   end
 
-  def test_integer_at_date_parts
+  def test_integer_at_positive_index
     s = create_string_scanner("2024-06-15")
     s.scan(/(\d{4})-(\d{2})-(\d{2})/)
     assert_equal(2024, s.integer_at(1))

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1117,13 +1117,6 @@ module StringScannerTests
     assert_equal(10, s.integer_at(1))
   end
 
-  def test_integer_at_full_match_with_non_digits
-    # follows String#to_i: "2024-06-15".to_i => 2024
-    s = create_string_scanner("2024-06-15")
-    s.scan(/\d{4}-\d{2}-\d{2}/)
-    assert_equal(2024, s.integer_at(0))
-  end
-
   def test_integer_at_named_capture_symbol
     s = create_string_scanner("2024-06-15")
     s.scan(/(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/)

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1036,10 +1036,10 @@ module StringScannerTests
     s.scan(/(\d+)/)
     assert_equal(("9" * 18).to_i, s.integer_at(1))
 
-    # 19 digits min on 64-bit ("1" * 19): smallest value with overflow check
-    s = create_string_scanner("1" * 19)
+    # 19 digits min on 64-bit ("1" + "0" * 18): smallest value with overflow check
+    s = create_string_scanner("1" + "0" * 18)
     s.scan(/(\d+)/)
-    assert_equal(("1" * 19).to_i, s.integer_at(1))
+    assert_equal(("1" + "0" * 18).to_i, s.integer_at(1))
 
     # negative 18 digits max on 64-bit
     s = create_string_scanner("-" + "9" * 18)

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1120,7 +1120,7 @@ module StringScannerTests
   def test_integer_at_full_match_with_non_digits
     # follows String#to_i: "2024-06-15".to_i => 2024
     s = create_string_scanner("2024-06-15")
-    s.scan(/(\d{4})-(\d{2})-(\d{2})/)
+    s.scan(/\d{4}-\d{2}-\d{2}/)
     assert_equal(2024, s.integer_at(0))
   end
 

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1133,7 +1133,7 @@ module StringScannerTests
     assert_equal(15, s.integer_at("day"))
   end
 
-  def test_integer_at_named_capture_undefined
+  def test_integer_at_named_capture_unknown
     s = create_string_scanner("2024-06-15")
     s.scan(/(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/)
     assert_raise(IndexError) { s.integer_at(:unknown) }

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1044,6 +1044,28 @@ module StringScannerTests
     s = create_string_scanner("-9999999999999999999")
     s.scan(/([+\-]?\d+)/)
     assert_equal(-9999999999999999999, s.integer_at(1))
+
+    # LONG_MAX (19 digits, fits in long)
+    long_max = 2 ** (0.size * 8 - 1) - 1
+    s = create_string_scanner(long_max.to_s)
+    s.scan(/(\d+)/)
+    assert_equal(long_max, s.integer_at(1))
+
+    # LONG_MIN (19 digits + sign, fits in long)
+    long_min = -(2 ** (0.size * 8 - 1))
+    s = create_string_scanner(long_min.to_s)
+    s.scan(/([+\-]?\d+)/)
+    assert_equal(long_min, s.integer_at(1))
+
+    # LONG_MAX + 1 (bignum)
+    s = create_string_scanner((long_max + 1).to_s)
+    s.scan(/(\d+)/)
+    assert_equal(long_max + 1, s.integer_at(1))
+
+    # leading zeros with many digits
+    s = create_string_scanner("00000000000000000001")
+    s.scan(/(\d+)/)
+    assert_equal(1, s.integer_at(1))
   end
 
   def test_integer_at_non_digit

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -978,7 +978,7 @@ module StringScannerTests
 
   def test_integer_at_index_zero
     s = create_string_scanner("42 abc")
-    s.scan(/(\d+)/)
+    s.scan(/\d+/)
     assert_equal(42, s.integer_at(0))
   end
 

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1161,6 +1161,16 @@ module StringScannerTests
     s = create_string_scanner("1_0_0")
     s.scan(/(\d+(?:_\d+)*)/)
     assert_equal(100, s.integer_at(1))
+
+    # large number with underscores
+    s = create_string_scanner("1_000_000_000")
+    s.scan(/(\d+(?:_\d+)*)/)
+    assert_equal(1_000_000_000, s.integer_at(1))
+
+    # signed with underscores
+    s = create_string_scanner("-1_000")
+    s.scan(/([+\-]?\d+(?:_\d+)*)/)
+    assert_equal(-1000, s.integer_at(1))
   end
 
   def test_scan_integer

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1074,7 +1074,7 @@ module StringScannerTests
     assert_equal(long_min - 1, s.integer_at(1))
 
     # leading zeros with many digits
-    s = create_string_scanner("00000000000000000001")
+    s = create_string_scanner("0" * 19 + "1")
     s.scan(/(\d+)/)
     assert_equal(1, s.integer_at(1))
   end

--- a/test/strscan/test_stringscanner.rb
+++ b/test/strscan/test_stringscanner.rb
@@ -1011,10 +1011,10 @@ module StringScannerTests
 
   def test_integer_at_optional_group_not_matched
     s = create_string_scanner("2024-06")
-    s.scan(/(\d{4})-(\d{2})(-(\d{2}))?/)
+    s.scan(/(\d{4})-(\d{2})-?(\d{2})?/)
     assert_equal(2024, s.integer_at(1))
     assert_equal(6, s.integer_at(2))
-    assert_nil(s.integer_at(4))
+    assert_nil(s.integer_at(3))
   end
 
   def test_integer_at_large_number


### PR DESCRIPTION
The specification for `MatchData#integer_at` has been defined [here](https://bugs.ruby-lang.org/issues/21932#note-7). `StringScanner#integer_at` follows this specification.

see: https://bugs.ruby-lang.org/issues/21932#note-6, https://bugs.ruby-lang.org/issues/21932#note-7
see: https://bugs.ruby-lang.org/issues/21943