### PR TITLE
Fix `call-seq` formatting

### DIFF
--- a/doc/strscan/methods/get_byte.md
+++ b/doc/strscan/methods/get_byte.md
@@ -1,6 +1,3 @@
-call-seq:
-  get_byte -> byte_as_character or nil
-
 Returns the next byte, if available:
 
 - If the [position][2]

--- a/doc/strscan/methods/get_charpos.md
+++ b/doc/strscan/methods/get_charpos.md
@@ -1,6 +1,3 @@
-call-seq:
-  charpos -> character_position
-
 Returns the [character position][7] (initially zero),
 which may be different from the [byte position][2]
 given by method #pos:

--- a/doc/strscan/methods/get_pos.md
+++ b/doc/strscan/methods/get_pos.md
@@ -1,6 +1,3 @@
-call-seq:
-  pos -> byte_position
-
 Returns the integer [byte position][2],
 which may be different from the [character position][7]:
 

--- a/doc/strscan/methods/getch.md
+++ b/doc/strscan/methods/getch.md
@@ -1,6 +1,3 @@
-call-seq:
-  getch -> character or nil
-
 Returns the next (possibly multibyte) character,
 if available:
 

--- a/doc/strscan/methods/scan.md
+++ b/doc/strscan/methods/scan.md
@@ -1,6 +1,3 @@
-call-seq:
-  scan(pattern) -> substring or nil
-
 Attempts to [match][17] the given `pattern`
 at the beginning of the [target substring][3].
 

--- a/doc/strscan/methods/scan_until.md
+++ b/doc/strscan/methods/scan_until.md
@@ -1,6 +1,3 @@
-call-seq:
-  scan_until(pattern) -> substring or nil
-
 Attempts to [match][17] the given `pattern`
 anywhere (at any [position][2]) in the [target substring][3].
 

--- a/doc/strscan/methods/set_pos.md
+++ b/doc/strscan/methods/set_pos.md
@@ -1,7 +1,3 @@
-call-seq:
-  pos = n -> n
-  pointer = n -> n
-
 Sets the [byte position][2] and the [character position][11];
 returns `n`.
 

--- a/doc/strscan/methods/skip.md
+++ b/doc/strscan/methods/skip.md
@@ -1,6 +1,3 @@
-call-seq:
-  skip(pattern) match_size or nil
-
 Attempts to [match][17] the given `pattern`
 at the beginning of the [target substring][3];
 

--- a/doc/strscan/methods/skip_until.md
+++ b/doc/strscan/methods/skip_until.md
@@ -1,6 +1,3 @@
-call-seq:
-  skip_until(pattern) -> matched_substring_size or nil
-
 Attempts to [match][17] the given `pattern`
 anywhere (at any [position][2]) in the [target substring][3].
 

--- a/doc/strscan/methods/terminate.md
+++ b/doc/strscan/methods/terminate.md
@@ -1,6 +1,3 @@
-call-seq:
-  terminate -> self
-
 Sets the scanner to end-of-string;
 returns +self+:
 

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -410,6 +410,9 @@ strscan_reset(VALUE self)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   terminate -> self
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/terminate.md
  */
@@ -539,6 +542,9 @@ strscan_concat(VALUE self, VALUE str)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   pos -> byte_position
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/get_pos.md
  */
@@ -553,6 +559,9 @@ strscan_get_pos(VALUE self)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   charpos -> character_position
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/get_charpos.md
  */
@@ -568,6 +577,10 @@ strscan_get_charpos(VALUE self)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   pos = n -> n
+ *   pointer = n -> n
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/set_pos.md
  */
@@ -792,6 +805,9 @@ strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   scan(pattern) -> substring or nil
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/scan.md
  */
@@ -865,6 +881,9 @@ strscan_match_p(VALUE self, VALUE re)
 
 /*
  * :markup: markdown
+ * call-seq:
+ *   skip(pattern) match_size or nil
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/skip.md
  */
@@ -962,6 +981,9 @@ strscan_scan_full(VALUE self, VALUE re, VALUE s, VALUE f)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   scan_until(pattern) -> substring or nil
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/scan_until.md
  */
@@ -1036,6 +1058,9 @@ strscan_exist_p(VALUE self, VALUE re)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   skip_until(pattern) -> matched_substring_size or nil
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/skip_until.md
  */
@@ -1147,6 +1172,9 @@ adjust_registers_to_matched(struct strscanner *p)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   getch -> character or nil
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/getch.md
  */
@@ -1220,6 +1248,9 @@ strscan_peek_byte(VALUE self)
 
 /*
  * :markup: markdown
+ * :call-seq:
+ *   get_byte -> byte_as_character or nil
+ *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/get_byte.md
  */


### PR DESCRIPTION
They don't work in included markdown and also need a leading `:`

<img width="791" height="442" alt="grafik" src="https://github.com/user-attachments/assets/eca5d4c2-9597-4c58-a0cc-a4e2c9109992" />
