### PR TITLE
Fix call-seq return values

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -822,7 +822,7 @@ strscan_scan(VALUE self, VALUE re)
  * :include: strscan/link_refs.txt
  *
  * call-seq:
- *   match?(pattern) -> updated_position or nil
+ *   match?(pattern) -> match_size or nil
  *
  * Attempts to [match][17] the given `pattern`
  * at the beginning of the [target substring][3];
@@ -882,7 +882,7 @@ strscan_match_p(VALUE self, VALUE re)
 /*
  * :markup: markdown
  * call-seq:
- *   skip(pattern) match_size or nil
+ *   skip(pattern) -> match_size or nil
  *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/skip.md
@@ -956,7 +956,7 @@ strscan_check(VALUE self, VALUE re)
 
 /*
  * call-seq:
- *   scan_full(pattern, advance_pointer_p, return_string_p) -> matched_substring or nil
+ *   scan_full(pattern, advance_pointer_p, return_string_p) -> matched_substring or length or nil
  *
  * Equivalent to one of the following:
  *
@@ -1202,7 +1202,7 @@ strscan_getch(VALUE self)
 
 /*
  * call-seq:
- *   scan_byte -> integer_byte
+ *   scan_byte -> integer_byte or nil
  *
  * Scans one byte and returns it as an integer.
  * This method is not multibyte character sensitive.


### PR DESCRIPTION
Some `call-seq` comments did not match the actual return values (documentation only, no behavior change):

* `match?` returns the match size, not a position
* `skip` was missing the `->` arrow
* `scan_full` can also return a length
* `scan_byte` can return `nil` at end of string