### PR TITLE
Constrain rdoc and rbs on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,15 @@ gemspec
 group :development do
   gem "benchmark-driver"
   gem "rake-compiler"
-  gem "rdoc"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
+    # rdoc 8 depends on rbs 4, which requires Ruby 3.2 or later.
+    gem "rdoc", "< 8"
+  else
+    gem "rdoc"
+    # rdoc 8 depends on rbs, which has no java platform gem before 4.1.0.pre.2.
+    # See https://github.com/ruby/rdoc/issues/1746
+    gem 'rbs', '>= 4.1.0.pre.2' if RUBY_PLATFORM == 'java'
+  end
   gem "ruby-maven", :platforms => :jruby
   gem "test-unit"
   gem "test-unit-ruby-core"


### PR DESCRIPTION
JRuby 9.4 (equivalent to 3.1) cannot resolve the RBS dependencies specific to Ruby 3.2 and later that are included in rdoc 8. On the other hand, rbs has no java platform gem before 4.1.0.pre.2.