### PR TITLE
Remove obsolete constants

### DIFF
--- a/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/ext/jruby/org/jruby/ext/strscan/RubyStringScanner.java
@@ -87,18 +87,10 @@ public class RubyStringScanner extends RubyObject {
 
         RubyClass standardError = runtime.getStandardError();
         RubyClass error = scannerClass.defineClassUnder("Error", standardError, standardError.getAllocator());
-        if (!Object.isConstantDefined("ScanError", true)) {
-            Object.defineConstant("ScanError", error);
-            Object.deprecateConstant(runtime, "ScanError");
-        }
 
         RubyString version = runtime.newString(STRSCAN_VERSION);
         version.setFrozen(true);
         scannerClass.setConstant("Version", version);
-        RubyString id = runtime.newString("$Id$");
-        id.setFrozen(true);
-        scannerClass.setConstant("Id", id);
-        scannerClass.deprecateConstant(runtime, "Id");
 
         scannerClass.defineAnnotatedMethods(RubyStringScanner.class);
 

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -2384,7 +2384,6 @@ Init_strscan(void)
 #endif
 
 #undef rb_intern
-    ID id_scanerr = rb_intern("ScanError");
     VALUE tmp;
 
     usascii_encindex = rb_usascii_encindex();
@@ -2393,17 +2392,9 @@ Init_strscan(void)
 
     StringScanner = rb_define_class("StringScanner", rb_cObject);
     ScanError = rb_define_class_under(StringScanner, "Error", rb_eStandardError);
-    if (!rb_const_defined(rb_cObject, id_scanerr)) {
-	rb_const_set(rb_cObject, id_scanerr, ScanError);
-	rb_deprecate_constant(rb_cObject, "ScanError");
-    }
     tmp = rb_str_new2(STRSCAN_VERSION);
     rb_obj_freeze(tmp);
     rb_const_set(StringScanner, rb_intern("Version"), tmp);
-    tmp = rb_str_new2("$Id$");
-    rb_obj_freeze(tmp);
-    rb_const_set(StringScanner, rb_intern("Id"), tmp);
-    rb_deprecate_constant(StringScanner, "Id");
 
     rb_define_alloc_func(StringScanner, strscan_s_allocate);
     rb_define_private_method(StringScanner, "initialize", strscan_initialize, -1);

--- a/lib/strscan/truffleruby.rb
+++ b/lib/strscan/truffleruby.rb
@@ -5,13 +5,7 @@ class StringScanner
   class Error < StandardError
   end
   # :stopdoc:
-  unless ::Object.const_defined?(:ScanError)
-    ::Object::ScanError = Error
-    ::Object.deprecate_constant :ScanError
-  end
-
   Version = '3.1.9'
-  Id = '$Id$'
 
   def self.must_C_version = self
   # :startdoc:


### PR DESCRIPTION
Undocumented `::ScanError` and `::Id`.  `StringScanner::ScanError` should be used instead of the former, and the latter is completely useless now.